### PR TITLE
Also make it work on Windows without having to set JAGS_ROOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .libs
 *.o
 *.so
-
+*.dll
+*.dylib

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,5 @@
-AC_INIT([rjags], [4])
+#Based configure.ac from rjags 4.9 (2020-04-29)
+AC_INIT([RoBMA], [4])
 
 if test -z "${R_HOME}"; then
    AC_MSG_ERROR("R_HOME is not defined")

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,12 @@
+#Set a default value for JAGS_ROOT in case the user hasn't set it, this location was specified by the CRAN-team (according to runjags, where I copied this from)
+JAGS_ROOT ?= c:/progra~1/JAGS/JAGS-4.3.0
+
+## Use the old ABI to match JAGS 4.x compilation on Windows:
+PKG_CXXFLAGS = -D_GLIBCXX_USE_CXX11_ABI=0
+
 PKG_CPPFLAGS=-I"$(JAGS_ROOT)/include" 
 PKG_LIBS=-L"$(JAGS_ROOT)/${R_ARCH}/bin" -ljags-4 -ljrmath-0
 
+# Actual sources and objects for RoBMA
 SOURCES= $(wildcard *.cc) $(wildcard */*.cc)
 OBJECTS=$(SOURCES:.cc=.o)


### PR DESCRIPTION
(But if you install JAGS somewhere else then C:\Program Files\JAGS\JAGS-0.4.3 then you should set it.)