### PR TITLE
Add usage examples to documentation and R functions

### DIFF
--- a/R/NoBMA.R
+++ b/R/NoBMA.R
@@ -17,6 +17,14 @@
 #' @return \code{NoBMA} returns an object of class 'RoBMA'.
 #'
 #' @seealso [RoBMA()], [summary.RoBMA()], [update.RoBMA()], [check_setup()]
+#' @examples
+#' \dontrun{
+#' # fit a publication bias unadjusted meta-analysis
+#' data(Andrews2021)
+#' fit <- NoBMA(~ measure + age, data = Andrews2021, parallel = TRUE,
+#'              seed = 1, algorithm = "ss")
+#' summary(fit)
+#' }
 #' @export
 NoBMA <- function(
     # data specification

--- a/R/check-input-and-settings.R
+++ b/R/check-input-and-settings.R
@@ -12,6 +12,19 @@
 #'
 #' @seealso [check_setup.reg()] [RoBMA()]
 #' @aliases check_setup.RoBMA
+#' @examples
+#' # check default RoBMA setup
+#' check_setup()
+#' 
+#' # check setup with custom priors
+#' check_setup(
+#'   priors_effect = prior("normal", list(mean = 0, sd = 0.5)),
+#'   priors_heterogeneity = prior("invgamma", list(shape = 2, scale = 0.3)),  
+#'   models = TRUE
+#' )
+#' 
+#' # show detailed model overview
+#' check_setup(models = TRUE)
 #' @export
 check_setup <- function(
   model_type   = NULL,
@@ -168,6 +181,15 @@ check_setup.RoBMA <- check_setup
 #'
 #' @seealso [check_setup()] [RoBMA.reg()]
 #' @aliases check_setup.RoBMA.reg
+#' @examples
+#' # check regression setup with example data
+#' data(Andrews2021)
+#' check_setup.reg(~ measure + age, data = Andrews2021)
+#' 
+#' # check setup with custom priors
+#' check_setup.reg(~ measure + age, data = Andrews2021,
+#'                 priors_effect = prior("normal", list(mean = 0, sd = 0.5),
+#'                 prior_weight = 2))
 #' @export
 check_setup.reg <- function(
     formula, data, test_predictors = TRUE, study_names = NULL, study_ids = NULL,

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -39,6 +39,20 @@
 #' @name weighted_normal
 #'
 #' @seealso \link[stats]{Normal}
+#' @examples
+#' # generate random samples from weighted normal distribution
+#' samples <- rwnorm(n = 10000, mean = 0.15, sd = 0.10, 
+#'                   steps = c(0.025, 0.5), omega = c(0.1, 0.5, 1), 
+#'                   type = "one.sided")
+#' # hist(samples)
+#' 
+#' # compute density at specific values
+#' density_vals <- dwnorm(x = c(-2, 0, 2), mean = 0, sd = 1, 
+#'                        steps = c(0.05), omega = c(0.5, 1))
+#' 
+#' # compute cumulative probabilities  
+#' prob_vals <- pwnorm(q = c(-1, 0, 1), mean = 0, sd = 1,
+#'                     steps = c(0.05), omega = c(0.5, 1))
 NULL
 
 #' @rdname weighted_normal

--- a/man/NoBMA.Rd
+++ b/man/NoBMA.Rd
@@ -211,6 +211,15 @@ See \code{\link[=RoBMA]{RoBMA()}} for more details.
 Note that these default prior distributions are relatively wide and more informed
 prior distributions for testing for the presence of moderation should be considered.
 }
+\examples{
+\dontrun{
+# fit a publication bias unadjusted meta-analysis
+data(Andrews2021)
+fit <- NoBMA(~ measure + age, data = Andrews2021, parallel = TRUE,
+             seed = 1, algorithm = "ss")
+summary(fit)
+}
+}
 \seealso{
 \code{\link[=RoBMA]{RoBMA()}}, \code{\link[=summary.RoBMA]{summary.RoBMA()}}, \code{\link[=update.RoBMA]{update.RoBMA()}}, \code{\link[=check_setup]{check_setup()}}
 }

--- a/man/check_setup.Rd
+++ b/man/check_setup.Rd
@@ -137,6 +137,20 @@ Note that this is an experimental feature and see News for more details. Default
 implied by the specified prior distributions. It is useful for checking
 the ensemble configuration prior to fitting all of the models.
 }
+\examples{
+# check default RoBMA setup
+check_setup()
+
+# check setup with custom priors
+check_setup(
+  priors_effect = prior("normal", list(mean = 0, sd = 0.5)),
+  priors_heterogeneity = prior("invgamma", list(shape = 2, scale = 0.3)),  
+  models = TRUE
+)
+
+# show detailed model overview
+check_setup(models = TRUE)
+}
 \seealso{
 \code{\link[=check_setup.reg]{check_setup.reg()}} \code{\link[=RoBMA]{RoBMA()}}
 }

--- a/man/check_setup.reg.Rd
+++ b/man/check_setup.reg.Rd
@@ -313,6 +313,16 @@ the ensemble configuration prior to fitting all of the models.
 implied by the specified prior distributions. It is useful for checking
 the ensemble configuration prior to fitting all of the models.
 }
+\examples{
+# check regression setup with example data
+data(Andrews2021)
+check_setup.reg(~ measure + age, data = Andrews2021)
+
+# check setup with custom priors
+check_setup.reg(~ measure + age, data = Andrews2021,
+                priors_effect = prior("normal", list(mean = 0, sd = 0.5),
+                prior_weight = 2))
+}
 \seealso{
 \code{\link[=check_setup]{check_setup()}} \code{\link[=RoBMA.reg]{RoBMA.reg()}}
 

--- a/man/weighted_normal.Rd
+++ b/man/weighted_normal.Rd
@@ -98,6 +98,21 @@ supplied as a vectors (\code{mean}, \code{sd}) or matrices (\code{steps},
 \code{omega}) with length / number of rows equal to \code{x}/\code{q}/
 \code{p}. Otherwise, they are recycled to the length of the result.
 }
+\examples{
+# generate random samples from weighted normal distribution
+samples <- rwnorm(n = 10000, mean = 0.15, sd = 0.10, 
+                  steps = c(0.025, 0.5), omega = c(0.1, 0.5, 1), 
+                  type = "one.sided")
+# hist(samples)
+
+# compute density at specific values
+density_vals <- dwnorm(x = c(-2, 0, 2), mean = 0, sd = 1, 
+                       steps = c(0.05), omega = c(0.5, 1))
+
+# compute cumulative probabilities  
+prob_vals <- pwnorm(q = c(-1, 0, 1), mean = 0, sd = 1,
+                    steps = c(0.05), omega = c(0.5, 1))
+}
 \seealso{
 \link[stats]{Normal}
 }


### PR DESCRIPTION
Added @examples for NoBMA, check_setup, check_setup.reg, and weighted_normal functions. Updated corresponding .Rd manual files to include these examples, demonstrating typical usage and custom prior specification.