### PR TITLE
fixes a bug in forest() where study names are not shown

### DIFF
--- a/R/transformations.R
+++ b/R/transformations.R
@@ -535,7 +535,7 @@ combine_data  <- function(d = NULL, r = NULL, z = NULL, logOR = NULL, OR = NULL,
     logORse  <- sqrt( 1/data$x1 + 1/data$x2 + 1/(data$n1 - data$x1) + 1/(data$n2 - data$x2) )
 
     # Delegate to standard combine_data() for further transformations
-    return(combine_data(logOR = logOR, se = logORse, study_names = study_names, study_ids = study_ids, weight = weight,
+    return(combine_data(logOR = logOR, se = logORse, study_names = if(length(data$study_names)==nrow(data)) data$study_names else study_names, study_ids = study_ids, weight = weight,
                         transformation = .transformation_invar(transformation, estimation = if(is.null(dots[["estimation"]])) FALSE else dots[["estimation"]]), estimation = if(is.null(dots[["estimation"]])) FALSE else dots[["estimation"]], return_all = return_all))
   }
 


### PR DESCRIPTION
 the study_name column in the dataset is overridden and regenerated as the data is not passed to combine_data() from .combine_data_bi() which is called within forest() which causes the study names to be regenerated sequentially and therefore incorrectly shown on the plot; this seemed like the lowest impact way to fix it, just to pass the study names directly to combine_data() as an argument