### PR TITLE
Updates for JAGS 5.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-SystemRequirements: JAGS >= 4.3.1 (https://mcmc-jags.sourceforge.io/)
+SystemRequirements: JAGS >= 5.0.0 (https://mcmc-jags.sourceforge.io/)
 NeedsCompilation: yes
 Depends:
     R (>= 4.0.0)

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -7,7 +7,7 @@
 ###
 ###  Note:  This windows makefile requires the JAGS_ROOT variable to be set
 ###
-###  This file allows compilation with JAGS 4 (or later) without modifying RoBMA.
+###  This file allows compilation with JAGS 5 (or later) without modifying RoBMA.
 ###  To force the package to compile assuming a given JAGS version is installed, use the
 ###  JAGS_MAJOR_FORCED environmental variable.  This might be necessary on windows if you have
 ###  JAGS installed in a non-standard location.
@@ -15,13 +15,7 @@
 ######################################################################################################
 
 ## Conditionally set the JAGS_ROOT variable (if it is not already set) to a location specified by the CRAN team:
-JAGS_ROOT ?= /c/progra~1/JAGS/JAGS-4.3.1
-
-## Use the old ABI to match JAGS 4.x compilation on Windows:
-#PKG_CXXFLAGS = -D_GLIBCXX_USE_CXX11_ABI=0
-PKG_CXXFLAGS=
-## Note: this behaviour will be changed (and RoBMA updated) before JAGS 5 is released
-## If you are trying to compile this version of RoBMA against JAGS 5 you may need to remove this PKG_CXXFLAGS line
+JAGS_ROOT ?= /c/progra~1/JAGS/JAGS-5.0.0
 
 ###############
 ###  Flags
@@ -52,7 +46,7 @@ JAGS_FULL_VERS = $(word $(words $(JAGS_ROOT_SUB)),$(JAGS_ROOT_SUB))
 JAGS_MAJOR_ASSUMED = $(strip $(word 2,$(subst .,$(space),$(subst -,$(space),$(JAGS_FULL_VERS)))))
 else
 # Otherwise make an assumption about JAGS_MAJOR and give a warning:
-JAGS_MAJOR_ASSUMED = $(strip 4)
+JAGS_MAJOR_ASSUMED = $(strip 5)
 $(warning The major version of JAGS could not be determined from $(JAGS_ROOT) - assuming version $(JAGS_MAJOR_ASSUMED) (otherwise the Makevars.win file may need to be modified))
 endif
 
@@ -62,14 +56,14 @@ endif
 
 # Set the CPPFLAGS accordingly
 # Prepending 0 to JAGS_MAJOR_VERSION prevents it being set as blank (the C++ code requires a number)
-JAGS_MAJOR_ASSUMED := 4
+JAGS_MAJOR_ASSUMED := 5
 PKG_CPPFLAGS=-I"$(JAGS_ROOT)/include" -D JAGS_MAJOR_ASSUMED=$(JAGS_MAJOR_ASSUMED) -D JAGS_MAJOR_FORCED=0$(JAGS_MAJOR_VERSION) -DR_NO_REMAP
 
 PKG_LIBS=-L"$(JAGS_ROOT)/${R_ARCH}/bin" -ljags-$(JAGS_MAJOR) -ljrmath-0 -llapack
 
 ###############
 ### Objects to be compiled
-### NB: the objects in distributions/jags are only necessary for JAGS <=3, and are excluded by the sources when compiling against JAGS >= 4
+### NB: the objects in distributions/jags are only necessary for JAGS <=3, and are excluded by the sources when compiling against JAGS >= 5
 ###############
 
 OBJECTS = distributions/DMN.o distributions/DWMN1.o distributions/DWMN2.o distributions/DMNv.o distributions/DWMN1v.o distributions/DWMN2v.o \
@@ -92,7 +86,7 @@ OBJECTS = distributions/DMN.o distributions/DWMN1.o distributions/DWMN2.o distri
 ###############
 
 # PKG_CPPFLAGS=-I"$(JAGS_ROOT)/include"
-# PKG_LIBS=-L"$(JAGS_ROOT)/${R_ARCH}/bin" -ljags-4 -llapack
+# PKG_LIBS=-L"$(JAGS_ROOT)/${R_ARCH}/bin" -ljags-5 -llapack
 # OBJECTS = distributions/DMN.o distributions/DWMN1.o distributions/DWMN2.o distributions/DMNv.o distributions/DWMN1v.o distributions/DWMN2v.o \
 #		  distributions/DWN1.o distributions/DWN2.o distributions/DWT1.o distributions/DWT2.o  \
 #		  distributions/DWN.o distributions/DWWN1.o distributions/DWWN2.o \

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -15,12 +15,7 @@
 ######################################################################################################
 
 ## Conditionally set the JAGS_ROOT variable (if it is not already set) to a location specified by the CRAN team:
-JAGS_ROOT ?= /c/progra~1/JAGS/JAGS-4.3.1
-
-## Use the old ABI to match JAGS 4.x compilation on Windows:
-PKG_CXXFLAGS = -D_GLIBCXX_USE_CXX11_ABI=0
-## Note: this behaviour will be changed (and RoBMA updated) before JAGS 5 is released
-## If you are trying to compile this version of RoBMA against JAGS 5 you may need to remove this PKG_CXXFLAGS line
+JAGS_ROOT ?= /c/progra~1/JAGS/JAGS-5.0.0
 
 ###############
 ###  Flags
@@ -51,7 +46,7 @@ JAGS_FULL_VERS = $(word $(words $(JAGS_ROOT_SUB)),$(JAGS_ROOT_SUB))
 JAGS_MAJOR_ASSUMED = $(strip $(word 2,$(subst .,$(space),$(subst -,$(space),$(JAGS_FULL_VERS)))))
 else
 # Otherwise make an assumption about JAGS_MAJOR and give a warning:
-JAGS_MAJOR_ASSUMED = $(strip 4)
+JAGS_MAJOR_ASSUMED = $(strip 5)
 $(warning The major version of JAGS could not be determined from $(JAGS_ROOT) - assuming version $(JAGS_MAJOR_ASSUMED) (otherwise the Makevars.win file may need to be modified))
 endif
 
@@ -72,7 +67,7 @@ PKG_LIBS=-L"$(JAGS_ROOT)/${R_ARCH}/bin" -ljags-$(JAGS_MAJOR) -ljrmath-0 -llapack
 ###############
 
 OBJECTS = distributions/DMN.o distributions/DWMN1.o distributions/DWMN2.o distributions/DMNv.o distributions/DWMN1v.o distributions/DWMN2v.o \
- 		  distributions/DWN1.o distributions/DWN2.o distributions/DWT1.o distributions/DWT2.o  \
+		  distributions/DWN1.o distributions/DWN2.o distributions/DWT1.o distributions/DWT2.o  \
 		  distributions/DWN.o distributions/DWWN1.o distributions/DWWN2.o \
 		  distributions/DWB.o \
 		  distributions/DWNMIX.o distributions/DWWNMIX.o \
@@ -91,7 +86,7 @@ OBJECTS = distributions/DMN.o distributions/DWMN1.o distributions/DWMN2.o distri
 ###############
 
 # PKG_CPPFLAGS=-I"$(JAGS_ROOT)/include"
-# PKG_LIBS=-L"$(JAGS_ROOT)/${R_ARCH}/bin" -ljags-4 -ljrmath-0 -llapack
+# PKG_LIBS=-L"$(JAGS_ROOT)/${R_ARCH}/bin" -ljags-5 -ljrmath-0 -llapack
 # OBJECTS = distributions/DMN.o distributions/DWMN1.o distributions/DWMN2.o distributions/DMT2v.o distributions/DWMT1v.o distributions/DWMT2v.o \
 # 	  	    distributions/DWN1.o distributions/DWN2.o distributions/DWT1.o distributions/DWT2.o  \
 # 		    distributions/DWN.o distributions/DWWN1.o distributions/DWWN2.o \

--- a/src/distributions/DMN.cc
+++ b/src/distributions/DMN.cc
@@ -15,12 +15,12 @@
 namespace jags {
   namespace RoBMA {
 
-    std::vector<unsigned int> DMN::dim(std::vector<std::vector<unsigned int> > const &dims) const
+    std::vector<unsigned long> DMN::dim(std::vector<std::vector<unsigned long> > const &dims) const
     {
-      return std::vector<unsigned int>(1,dims[0][0]);
+      return std::vector<unsigned long>(1,dims[0][0]);
     }
 
-    bool DMN::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool DMN::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       bool sigma_OK  = true; // check that sigma and mu dimension matches
 
@@ -29,7 +29,7 @@ namespace jags {
       return sigma_OK;
     }
 
-    bool DMN::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+    bool DMN::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       const double *sigma  = par[1];
 
@@ -49,8 +49,8 @@ namespace jags {
 
     DMN::DMN():ArrayDist("dmnorm", 2) {}
 
-    double DMN::logDensity(double const *x, unsigned int length, PDFType type, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims, double const *lower, double const *upper) const
+    double DMN::logDensity(double const *x, PDFType type, std::vector<double const *> const &par,
+			   std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *mu     = par[0];
@@ -64,31 +64,23 @@ namespace jags {
       return log_lik;
     }
 
-    void DMN::randomSample(double *x, unsigned int length, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper,
+    void DMN::randomSample(double *x, std::vector<double const *> const &par,
+              std::vector<std::vector<unsigned long> > const &dims,
               RNG *rng) const
     {
       // not implemented
     }
 
-    void DMN::support(double *lower, double *upper, unsigned int length,
+    void DMN::support(double *lower, double *upper,
               std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims) const
+              std::vector<std::vector<unsigned long> > const &dims) const
     {
+      unsigned long length = product(dim(dims));
       // no idea whether this is correct
-      for (unsigned int i = 0; i < length; ++i) {
+	for (unsigned long i = 0; i < length; ++i) {
         lower[i] = JAGS_NEGINF;
         upper[i] = JAGS_POSINF;
       }
-    }
-
-    void DMN::typicalValue(double *x, unsigned int length,
-              std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper) const
-    {
-      // not implemented
     }
 
     bool DMN::isSupportFixed(std::vector<bool> const &fixmask) const

--- a/src/distributions/DMN.h
+++ b/src/distributions/DMN.h
@@ -9,26 +9,21 @@ class DMN : public ArrayDist {
 public:
   DMN();
 
-  double logDensity(double const *x, unsigned int length, PDFType type,
+  double logDensity(double const *x, PDFType type,
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<std::vector<unsigned long> > const &dims) const override;
+  void randomSample(double *x,
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  bool checkParameterDim(std::vector<std::vector<unsigned int> > const &dims) const;
+		    std::vector<std::vector<unsigned long> > const &dims,
+		    RNG *rng) const override;
+  bool checkParameterDim(std::vector<std::vector<unsigned long> > const &dims) const;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-			std::vector<std::vector<unsigned int> > const &dims) const;
-  std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims) const;
-  void support(double *lower, double *upper, unsigned int length,
+			std::vector<std::vector<unsigned long> > const &dims) const override;
+  std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims) const override;
+  void support(double *lower, double *upper, 
 	       std::vector<double const *> const &parameters,
-	       std::vector<std::vector<unsigned int> > const &dims) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<std::vector<unsigned long> > const &dims) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
 };
 
 }}

--- a/src/distributions/DMNv.cc
+++ b/src/distributions/DMNv.cc
@@ -15,13 +15,13 @@
 namespace jags {
   namespace RoBMA {
 
-    std::vector<unsigned int> DMNv::dim(std::vector<std::vector<unsigned int> > const &dims) const
+    std::vector<unsigned long> DMNv::dim(std::vector<std::vector<unsigned long> > const &dims) const
     {
-      return std::vector<unsigned int>(1,dims[0][0]);
+      return std::vector<unsigned long>(1,dims[0][0]);
     }
 
 
-    bool DMNv::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool DMNv::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       bool se2_OK   = true; // check that standard errors squared and mu dimension matches
       bool tau2_OK  = true; // check that tau squared is a single double
@@ -35,7 +35,7 @@ namespace jags {
     }
 
 
-    bool DMNv::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+    bool DMNv::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       const double *tau2  = par[2];
       const double *rho   = par[3];
@@ -52,8 +52,8 @@ namespace jags {
 
     DMNv::DMNv():ArrayDist("dmnorm_v", 5) {}
 
-    double DMNv::logDensity(double const *x, unsigned int length, PDFType type, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims, double const *lower, double const *upper) const
+    double DMNv::logDensity(double const *x, PDFType type, std::vector<double const *> const &par,
+              std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *mu     = par[0];
@@ -96,31 +96,23 @@ namespace jags {
       return log_lik;
     }
 
-    void DMNv::randomSample(double *x, unsigned int length, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper,
+    void DMNv::randomSample(double *x, std::vector<double const *> const &par,
+              std::vector<std::vector<unsigned long> > const &dims,
               RNG *rng) const
     {
       // not implemented
     }
 
-    void DMNv::support(double *lower, double *upper, unsigned int length,
+    void DMNv::support(double *lower, double *upper,
               std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims) const
+              std::vector<std::vector<unsigned long> > const &dims) const
     {
-      // no idea whether this is correct
-      for (unsigned int i = 0; i < length; ++i) {
-        lower[i] = JAGS_NEGINF;
-        upper[i] = JAGS_POSINF;
-      }
-    }
-
-    void DMNv::typicalValue(double *x, unsigned int length,
-              std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper) const
-    {
-      // not implemented
+	unsigned long length = product(dim(dims));
+	// no idea whether this is correct
+	for (unsigned long i = 0; i < length; ++i) {
+	    lower[i] = JAGS_NEGINF;
+	    upper[i] = JAGS_POSINF;
+	}
     }
 
     bool DMNv::isSupportFixed(std::vector<bool> const &fixmask) const

--- a/src/distributions/DMNv.h
+++ b/src/distributions/DMNv.h
@@ -9,26 +9,20 @@ class DMNv : public ArrayDist {
 public:
   DMNv();
 
-  double logDensity(double const *x, unsigned int length, PDFType type,
+  double logDensity(double const *x,  PDFType type,
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<std::vector<unsigned long> > const &dims) const override;
+  void randomSample(double *x, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  bool checkParameterDim(std::vector<std::vector<unsigned int> > const &dims) const;
+		    std::vector<std::vector<unsigned long> > const &dims, RNG *rng) const override;
+  bool checkParameterDim(std::vector<std::vector<unsigned long> > const &dims) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-			std::vector<std::vector<unsigned int> > const &dims) const;
-  std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims) const;
-  void support(double *lower, double *upper, unsigned int length,
+			std::vector<std::vector<unsigned long> > const &dims) const override;
+  std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims) const override;
+  void support(double *lower, double *upper, 
 	       std::vector<double const *> const &parameters,
-	       std::vector<std::vector<unsigned int> > const &dims) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<std::vector<unsigned long> > const &dims) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
 };
 
 }}

--- a/src/distributions/DWB.cc
+++ b/src/distributions/DWB.cc
@@ -18,14 +18,14 @@ namespace RoBMA {
 DWB::DWB() : VectorDist("dwbinom", 3) {}
 
 
-bool DWB::checkParameterLength(std::vector<unsigned int> const &len) const
+bool DWB::checkParameterLength(std::vector<unsigned long> const &len) const
 {
   // there is one less cut-point then weights
   return true;
 }
 
 bool DWB::checkParameterValue(std::vector<double const *> const &par,
-			    std::vector<unsigned int> const &len) const
+			    std::vector<unsigned long> const &len) const
 {
   // p is between 0-1, n and weight are positive
   bool p_OK = *par[0] >= 0.0 && *par[0] <= 1.0 ; 
@@ -35,10 +35,9 @@ bool DWB::checkParameterValue(std::vector<double const *> const &par,
   return p_OK && N_OK && weight_OK;
 }
 
-double DWB::logDensity(double const *x, unsigned int length, PDFType type,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
+double DWB::logDensity(double const *x, PDFType type,
+		       std::vector<double const *> const &par,
+		       std::vector<unsigned long> const &len) const
 {
   double p = *par[0];
   double N = *par[1];
@@ -50,41 +49,30 @@ double DWB::logDensity(double const *x, unsigned int length, PDFType type,
   return log_lik;
 }
 
-void DWB::randomSample(double *x, unsigned int length,
+void DWB::randomSample(double *x,
 			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper,
+			  std::vector<unsigned long> const &len,
 			  RNG *rng) const
 {
   // not implemented
 }
 
-void DWB::support(double *lower, double *upper, unsigned int length,
+void DWB::support(double *lower, double *upper,
 	     std::vector<double const *> const &par,
-	     std::vector<unsigned int> const &len) const
+	     std::vector<unsigned long> const &len) const
 {
   // no idea whether this is correct
-  for (unsigned int i = 0; i < length; ++i) {
+  for (unsigned long i = 0; i < length(len); ++i) {
 	  lower[i] = JAGS_NEGINF;
 	  upper[i] = JAGS_POSINF;
   }
 }
 
-unsigned int DWB::length(std::vector<unsigned int> const &len) const
+unsigned long DWB::length(std::vector<unsigned long> const &len) const
 {
   // no idea how this works
   return 1;
 }
-
-
-void DWB::typicalValue(double *x, unsigned int length,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
-{
-  // not implemented
-}
-
 
 bool DWB::isSupportFixed(std::vector<bool> const &fixmask) const
 {

--- a/src/distributions/DWB.h
+++ b/src/distributions/DWB.h
@@ -10,26 +10,20 @@ class DWB : public VectorDist
   public:
     DWB();
     
-  double logDensity(double const *x, unsigned int length, PDFType tpye, 
+  double logDensity(double const *x,  PDFType tpye, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<unsigned long> const &lengths) const override;
+  void randomSample(double *x, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &par,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
+		    std::vector<unsigned long> const &lengths, RNG *rng) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-                           std::vector<unsigned int> const &lengths) const;
-  bool checkParameterLength(std::vector<unsigned int> const &lengths) const;
-  unsigned int length(std::vector<unsigned int> const &dim) const;
-  void support(double *lower, double *upper, unsigned int length,
+                           std::vector<unsigned long> const &lengths) const override;
+  bool checkParameterLength(std::vector<unsigned long> const &lengths) const override;
+  unsigned long length(std::vector<unsigned long> const &dim) const override;
+  void support(double *lower, double *upper, 
 	       std::vector<double const *> const &parameters,
-	       std::vector<unsigned int> const &lengths) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<unsigned long> const &lengths) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
   };
 
 }

--- a/src/distributions/DWMN1.cc
+++ b/src/distributions/DWMN1.cc
@@ -16,13 +16,13 @@
 namespace jags {
   namespace RoBMA {
 
-    std::vector<unsigned int> DWMN1::dim(std::vector<std::vector<unsigned int> > const &dims) const
+    std::vector<unsigned long> DWMN1::dim(std::vector<std::vector<unsigned long> > const &dims) const
     {
-      return std::vector<unsigned int>(1,dims[0][0]);
+      return std::vector<unsigned long>(1,dims[0][0]);
     }
 
 
-    bool DWMN1::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool DWMN1::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
 
       bool sigma_OK  = true; // check that sigma and mu dimension matches
@@ -41,7 +41,7 @@ namespace jags {
     }
 
 
-    bool DWMN1::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+    bool DWMN1::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
 
       const double *sigma  = par[1];
@@ -69,8 +69,8 @@ namespace jags {
 
     DWMN1::DWMN1():ArrayDist("dwmnorm_1s", 4) {}
 
-    double DWMN1::logDensity(double const *x, unsigned int length, PDFType type, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims, double const *lower, double const *upper) const
+    double DWMN1::logDensity(double const *x, PDFType type, std::vector<double const *> const &par,
+              std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *mu     = par[0];
@@ -88,31 +88,23 @@ namespace jags {
       return log_lik;
     }
 
-    void DWMN1::randomSample(double *x, unsigned int length, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper,
+    void DWMN1::randomSample(double *x, std::vector<double const *> const &par,
+              std::vector<std::vector<unsigned long> > const &dims,
               RNG *rng) const
     {
       // not implemented
     }
 
-    void DWMN1::support(double *lower, double *upper, unsigned int length,
+    void DWMN1::support(double *lower, double *upper,
               std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims) const
+              std::vector<std::vector<unsigned long> > const &dims) const
     {
+      unsigned long length = product(dim(dims));
       // no idea whether this is correct
-      for (unsigned int i = 0; i < length; ++i) {
+      for (unsigned long i = 0; i < length; ++i) {
         lower[i] = JAGS_NEGINF;
         upper[i] = JAGS_POSINF;
       }
-    }
-
-    void DWMN1::typicalValue(double *x, unsigned int length,
-              std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper) const
-    {
-      // not implemented
     }
 
     bool DWMN1::isSupportFixed(std::vector<bool> const &fixmask) const

--- a/src/distributions/DWMN1.h
+++ b/src/distributions/DWMN1.h
@@ -9,26 +9,20 @@ class DWMN1 : public ArrayDist {
 public:
   DWMN1();
 
-  double logDensity(double const *x, unsigned int length, PDFType type,
+  double logDensity(double const *x,  PDFType type,
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<std::vector<unsigned long> > const &dims) const override;
+  void randomSample(double *x, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  bool checkParameterDim(std::vector<std::vector<unsigned int> > const &dims) const;
+		    std::vector<std::vector<unsigned long> > const &dims, RNG *rng) const override;
+  bool checkParameterDim(std::vector<std::vector<unsigned long> > const &dims) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-			std::vector<std::vector<unsigned int> > const &dims) const;
-  std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims) const;
-  void support(double *lower, double *upper, unsigned int length,
+			std::vector<std::vector<unsigned long> > const &dims) const override;
+  std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims) const override;
+  void support(double *lower, double *upper, 
 	       std::vector<double const *> const &parameters,
-	       std::vector<std::vector<unsigned int> > const &dims) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<std::vector<unsigned long> > const &dims) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
 };
 
 }}

--- a/src/distributions/DWMN1v.cc
+++ b/src/distributions/DWMN1v.cc
@@ -16,13 +16,13 @@
 namespace jags {
   namespace RoBMA {
 
-    std::vector<unsigned int> DWMN1v::dim(std::vector<std::vector<unsigned int> > const &dims) const
+    std::vector<unsigned long> DWMN1v::dim(std::vector<std::vector<unsigned long> > const &dims) const
     {
-      return std::vector<unsigned int>(1,dims[0][0]);
+      return std::vector<unsigned long>(1,dims[0][0]);
     }
 
 
-    bool DWMN1v::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool DWMN1v::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       bool se2_OK    = true; // check that standard errors squared and mu dimension matches
       bool tau2_OK   = true; // check that tau squared is a single double
@@ -45,7 +45,7 @@ namespace jags {
     }
 
 
-    bool DWMN1v::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+    bool DWMN1v::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       const double *tau2   = par[2];
       const double *rho   = par[3];
@@ -70,8 +70,8 @@ namespace jags {
 
     DWMN1v::DWMN1v():ArrayDist("dwmnorm_1s_v", 7) {}
 
-    double DWMN1v::logDensity(double const *x, unsigned int length, PDFType type, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims, double const *lower, double const *upper) const
+    double DWMN1v::logDensity(double const *x, PDFType type, std::vector<double const *> const &par,
+              std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *mu     = par[0];
@@ -119,31 +119,23 @@ namespace jags {
       return log_lik;
     }
 
-    void DWMN1v::randomSample(double *x, unsigned int length, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper,
+    void DWMN1v::randomSample(double *x, std::vector<double const *> const &par,
+              std::vector<std::vector<unsigned long> > const &dims,
               RNG *rng) const
     {
       // not implemented
     }
 
-    void DWMN1v::support(double *lower, double *upper, unsigned int length,
+    void DWMN1v::support(double *lower, double *upper,
               std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims) const
+              std::vector<std::vector<unsigned long> > const &dims) const
     {
       // no idea whether this is correct
-      for (unsigned int i = 0; i < length; ++i) {
+      unsigned long length = product(dim(dims));
+      for (unsigned long i = 0; i < length; ++i) {
         lower[i] = JAGS_NEGINF;
         upper[i] = JAGS_POSINF;
       }
-    }
-
-    void DWMN1v::typicalValue(double *x, unsigned int length,
-              std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper) const
-    {
-      // not implemented
     }
 
     bool DWMN1v::isSupportFixed(std::vector<bool> const &fixmask) const

--- a/src/distributions/DWMN1v.h
+++ b/src/distributions/DWMN1v.h
@@ -9,26 +9,20 @@ class DWMN1v : public ArrayDist {
 public:
   DWMN1v();
 
-  double logDensity(double const *x, unsigned int length, PDFType type,
+  double logDensity(double const *x,  PDFType type,
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<std::vector<unsigned long> > const &dims) const override;
+  void randomSample(double *x, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  bool checkParameterDim(std::vector<std::vector<unsigned int> > const &dims) const;
+		    std::vector<std::vector<unsigned long> > const &dims, RNG *rng) const override;
+  bool checkParameterDim(std::vector<std::vector<unsigned long> > const &dims) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-			std::vector<std::vector<unsigned int> > const &dims) const;
-  std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims) const;
-  void support(double *lower, double *upper, unsigned int length,
+			std::vector<std::vector<unsigned long> > const &dims) const override;
+  std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims) const override;
+  void support(double *lower, double *upper, 
 	       std::vector<double const *> const &parameters,
-	       std::vector<std::vector<unsigned int> > const &dims) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<std::vector<unsigned long> > const &dims) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
 };
 
 }}

--- a/src/distributions/DWMN2.cc
+++ b/src/distributions/DWMN2.cc
@@ -16,13 +16,13 @@
 namespace jags {
   namespace RoBMA {
 
-    std::vector<unsigned int> DWMN2::dim(std::vector<std::vector<unsigned int> > const &dims) const
+    std::vector<unsigned long> DWMN2::dim(std::vector<std::vector<unsigned long> > const &dims) const
     {
-      return std::vector<unsigned int>(1,dims[0][0]);
+      return std::vector<unsigned long>(1,dims[0][0]);
     }
 
 
-    bool DWMN2::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool DWMN2::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       bool sigma_OK  = true; // check that sigma and mu dimension matches
       bool omega_OK  = true; // check that omega and crit_x dimension matches
@@ -41,7 +41,7 @@ namespace jags {
     }
 
 
-    bool DWMN2::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+    bool DWMN2::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       const double *sigma  = par[1];
       const double *omega  = par[3];
@@ -68,8 +68,8 @@ namespace jags {
 
     DWMN2::DWMN2():ArrayDist("dwmnorm_2s", 4) {}
 
-    double DWMN2::logDensity(double const *x, unsigned int length, PDFType type, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims, double const *lower, double const *upper) const
+    double DWMN2::logDensity(double const *x, PDFType type, std::vector<double const *> const &par,
+              std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *mu     = par[0];
@@ -87,31 +87,23 @@ namespace jags {
       return log_lik;
     }
 
-    void DWMN2::randomSample(double *x, unsigned int length, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper,
+    void DWMN2::randomSample(double *x, std::vector<double const *> const &par,
+              std::vector<std::vector<unsigned long> > const &dims,
               RNG *rng) const
     {
       // not implemented
     }
 
-    void DWMN2::support(double *lower, double *upper, unsigned int length,
+    void DWMN2::support(double *lower, double *upper,
               std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims) const
+              std::vector<std::vector<unsigned long> > const &dims) const
     {
+      unsigned long length = product(dim(dims));
       // no idea whether this is correct
-      for (unsigned int i = 0; i < length; ++i) {
+      for (unsigned long i = 0; i < length; ++i) {
         lower[i] = JAGS_NEGINF;
         upper[i] = JAGS_POSINF;
       }
-    }
-
-    void DWMN2::typicalValue(double *x, unsigned int length,
-              std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper) const
-    {
-      // not implemented
     }
 
     bool DWMN2::isSupportFixed(std::vector<bool> const &fixmask) const

--- a/src/distributions/DWMN2.h
+++ b/src/distributions/DWMN2.h
@@ -9,26 +9,20 @@ class DWMN2 : public ArrayDist {
 public:
   DWMN2();
 
-  double logDensity(double const *x, unsigned int length, PDFType type,
+  double logDensity(double const *x,  PDFType type,
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<std::vector<unsigned long> > const &dims) const override;
+  void randomSample(double *x, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  bool checkParameterDim(std::vector<std::vector<unsigned int> > const &dims) const;
+		    std::vector<std::vector<unsigned long> > const &dims, RNG *rng) const override;
+  bool checkParameterDim(std::vector<std::vector<unsigned long> > const &dims) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-			std::vector<std::vector<unsigned int> > const &dims) const;
-  std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims) const;
-  void support(double *lower, double *upper, unsigned int length,
+			std::vector<std::vector<unsigned long> > const &dims) const override;
+  std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims) const override;
+  void support(double *lower, double *upper, 
 	       std::vector<double const *> const &parameters,
-	       std::vector<std::vector<unsigned int> > const &dims) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<std::vector<unsigned long> > const &dims) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
 };
 
 }}

--- a/src/distributions/DWMN2v.cc
+++ b/src/distributions/DWMN2v.cc
@@ -9,6 +9,7 @@
 #include <array>
 
 #include <JRmath.h>
+
 #include "../source/mnorm.h"
 #include "../source/wmnorm.h"
 #include "../source/tools.h"
@@ -16,13 +17,13 @@
 namespace jags {
   namespace RoBMA {
 
-    std::vector<unsigned int> DWMN2v::dim(std::vector<std::vector<unsigned int> > const &dims) const
+    std::vector<unsigned long> DWMN2v::dim(std::vector<std::vector<unsigned long> > const &dims) const
     {
-      return std::vector<unsigned int>(1,dims[0][0]);
+      return std::vector<unsigned long>(1,dims[0][0]);
     }
 
 
-    bool DWMN2v::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool DWMN2v::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       bool se2_OK    = true; // check that standard errors squared and mu dimension matches
       bool tau2_OK   = true; // check that tau squared is a single double
@@ -45,7 +46,7 @@ namespace jags {
     }
 
 
-    bool DWMN2v::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+    bool DWMN2v::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       const double *tau2   = par[2];
       const double *rho    = par[3];
@@ -70,8 +71,8 @@ namespace jags {
 
     DWMN2v::DWMN2v():ArrayDist("dwmnorm_2s_v", 7) {}
 
-    double DWMN2v::logDensity(double const *x, unsigned int length, PDFType type, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims, double const *lower, double const *upper) const
+    double DWMN2v::logDensity(double const *x, PDFType type, std::vector<double const *> const &par,
+              std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *mu     = par[0];
@@ -119,31 +120,23 @@ namespace jags {
       return log_lik;
     }
 
-    void DWMN2v::randomSample(double *x, unsigned int length, std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper,
+    void DWMN2v::randomSample(double *x, std::vector<double const *> const &par,
+              std::vector<std::vector<unsigned long> > const &dims,
               RNG *rng) const
     {
       // not implemented
     }
 
-    void DWMN2v::support(double *lower, double *upper, unsigned int length,
+    void DWMN2v::support(double *lower, double *upper,
               std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims) const
+              std::vector<std::vector<unsigned long> > const &dims) const
     {
+      unsigned long length = product(dim(dims));
       // no idea whether this is correct
-      for (unsigned int i = 0; i < length; ++i) {
+      for (unsigned long i = 0; i < length; ++i) {
         lower[i] = JAGS_NEGINF;
         upper[i] = JAGS_POSINF;
       }
-    }
-
-    void DWMN2v::typicalValue(double *x, unsigned int length,
-              std::vector<double const *> const &par,
-              std::vector<std::vector<unsigned int> > const &dims,
-              double const *lower, double const *upper) const
-    {
-      // not implemented
     }
 
     bool DWMN2v::isSupportFixed(std::vector<bool> const &fixmask) const

--- a/src/distributions/DWMN2v.h
+++ b/src/distributions/DWMN2v.h
@@ -9,26 +9,20 @@ class DWMN2v : public ArrayDist {
 public:
   DWMN2v();
 
-  double logDensity(double const *x, unsigned int length, PDFType type,
+  double logDensity(double const *x,  PDFType type,
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<std::vector<unsigned long> > const &dims) const override;
+  void randomSample(double *x, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &parameters,
-		    std::vector<std::vector<unsigned int> > const &dims,
-		    double const *lower, double const *upper) const;
-  bool checkParameterDim(std::vector<std::vector<unsigned int> > const &dims) const;
+		    std::vector<std::vector<unsigned long> > const &dims, RNG *rng) const override;
+  bool checkParameterDim(std::vector<std::vector<unsigned long> > const &dims) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-			std::vector<std::vector<unsigned int> > const &dims) const;
-  std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims) const;
-  void support(double *lower, double *upper, unsigned int length,
+			std::vector<std::vector<unsigned long> > const &dims) const override;
+  std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims) const override;
+  void support(double *lower, double *upper, 
 	       std::vector<double const *> const &parameters,
-	       std::vector<std::vector<unsigned int> > const &dims) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<std::vector<unsigned long> > const &dims) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
 };
 
 }}

--- a/src/distributions/DWN.cc
+++ b/src/distributions/DWN.cc
@@ -21,14 +21,14 @@ namespace RoBMA {
 DWN::DWN() : VectorDist("dwnorm", 3) {}
 
 
-bool DWN::checkParameterLength(std::vector<unsigned int> const &len) const
+bool DWN::checkParameterLength(std::vector<unsigned long> const &len) const
 {
   // there is one less cut-point then weights
   return true;
 }
 
 bool DWN::checkParameterValue(std::vector<double const *> const &par,
-			    std::vector<unsigned int> const &len) const
+			    std::vector<unsigned long> const &len) const
 {
   // var and weight is positive
   bool var_OK = *par[1] > 0.0;
@@ -37,10 +37,9 @@ bool DWN::checkParameterValue(std::vector<double const *> const &par,
   return var_OK && weight_OK;
 }
 
-double DWN::logDensity(double const *x, unsigned int length, PDFType type,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
+double DWN::logDensity(double const *x, PDFType type,
+		       std::vector<double const *> const &par,
+		       std::vector<unsigned long> const &len) const
 {
   double mu  = *par[0];
   double var = 1/ *par[1];
@@ -52,41 +51,30 @@ double DWN::logDensity(double const *x, unsigned int length, PDFType type,
   return log_lik;
 }
 
-void DWN::randomSample(double *x, unsigned int length,
+void DWN::randomSample(double *x,
 			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper,
+			  std::vector<unsigned long> const &len,
 			  RNG *rng) const
 {
   // not implemented
 }
 
-void DWN::support(double *lower, double *upper, unsigned int length,
+void DWN::support(double *lower, double *upper,
 	     std::vector<double const *> const &par,
-	     std::vector<unsigned int> const &len) const
+	     std::vector<unsigned long> const &len) const
 {
   // no idea whether this is correct
-  for (unsigned int i = 0; i < length; ++i) {
+  for (unsigned long i = 0; i < length(len); ++i) {
 	  lower[i] = JAGS_NEGINF;
 	  upper[i] = JAGS_POSINF;
   }
 }
 
-unsigned int DWN::length(std::vector<unsigned int> const &len) const
+unsigned long DWN::length(std::vector<unsigned long> const &len) const
 {
   // no idea how this works
   return 1;
 }
-
-
-void DWN::typicalValue(double *x, unsigned int length,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
-{
-  // not implemented
-}
-
 
 bool DWN::isSupportFixed(std::vector<bool> const &fixmask) const
 {

--- a/src/distributions/DWN.h
+++ b/src/distributions/DWN.h
@@ -10,26 +10,20 @@ class DWN : public VectorDist
   public:
     DWN();
     
-  double logDensity(double const *x, unsigned int length, PDFType tpye, 
+  double logDensity(double const *x,  PDFType tpye, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<unsigned long> const &lengths) const override;
+  void randomSample(double *x, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &par,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
+		    std::vector<unsigned long> const &lengths, RNG *rng) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-                           std::vector<unsigned int> const &lengths) const;
-  bool checkParameterLength(std::vector<unsigned int> const &lengths) const;
-  unsigned int length(std::vector<unsigned int> const &dim) const;
-  void support(double *lower, double *upper, unsigned int length,
+                           std::vector<unsigned long> const &lengths) const override;
+  bool checkParameterLength(std::vector<unsigned long> const &lengths) const override;
+  unsigned long length(std::vector<unsigned long> const &dim) const override;
+  void support(double *lower, double *upper, 
 	       std::vector<double const *> const &parameters,
-	       std::vector<unsigned int> const &lengths) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<unsigned long> const &lengths) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
   };
 
 }

--- a/src/distributions/DWN1.cc
+++ b/src/distributions/DWN1.cc
@@ -24,14 +24,14 @@ namespace RoBMA {
 DWN1::DWN1() : VectorDist("dwnorm_1s", 4) {}
 
 
-bool DWN1::checkParameterLength(std::vector<unsigned int> const &len) const
+bool DWN1::checkParameterLength(std::vector<unsigned long> const &len) const
 {
   // there is one less cut-point then weights
   return n_crit_x(len) == n_omega(len) - 1;
 }
 
 bool DWN1::checkParameterValue(std::vector<double const *> const &par,
-			    std::vector<unsigned int> const &len) const
+			    std::vector<unsigned long> const &len) const
 {
   bool omega_OK  = true;
 
@@ -46,10 +46,9 @@ bool DWN1::checkParameterValue(std::vector<double const *> const &par,
   return omega_OK && var_OK;
 }
 
-double DWN1::logDensity(double const *x, unsigned int length, PDFType type,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
+double DWN1::logDensity(double const *x, PDFType type,
+			std::vector<double const *> const &par,
+			std::vector<unsigned long> const &len) const
 {
   // reassign the addresses to pointers
   const double *mu     = par[0];
@@ -67,41 +66,30 @@ double DWN1::logDensity(double const *x, unsigned int length, PDFType type,
   return log_lik;
 }
 
-void DWN1::randomSample(double *x, unsigned int length,
+void DWN1::randomSample(double *x,
 			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper,
+			  std::vector<unsigned long> const &len,
 			  RNG *rng) const
 {
   // not implemented
 }
 
-void DWN1::support(double *lower, double *upper, unsigned int length,
+void DWN1::support(double *lower, double *upper,
 	     std::vector<double const *> const &par,
-	     std::vector<unsigned int> const &len) const
+	     std::vector<unsigned long> const &len) const
 {
   // no idea whether this is correct
-  for (unsigned int i = 0; i < length; ++i) {
+  for (unsigned long i = 0; i < length(len); ++i) {
 	  lower[i] = JAGS_NEGINF;
 	  upper[i] = JAGS_POSINF;
   }
 }
 
-unsigned int DWN1::length(std::vector<unsigned int> const &len) const
+unsigned long DWN1::length(std::vector<unsigned long> const &len) const
 {
   // no idea how this works
   return 1;
 }
-
-
-void DWN1::typicalValue(double *x, unsigned int length,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
-{
-  // not implemented
-}
-
 
 bool DWN1::isSupportFixed(std::vector<bool> const &fixmask) const
 {

--- a/src/distributions/DWN1.h
+++ b/src/distributions/DWN1.h
@@ -10,26 +10,20 @@ class DWN1 : public VectorDist
   public:
     DWN1();
     
-  double logDensity(double const *x, unsigned int length, PDFType tpye, 
+  double logDensity(double const *x,  PDFType tpye, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<unsigned long> const &lengths) const override;
+  void randomSample(double *x, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &par,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
+		    std::vector<unsigned long> const &lengths, RNG *rng) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-                           std::vector<unsigned int> const &lengths) const;
-  bool checkParameterLength(std::vector<unsigned int> const &lengths) const;
-  unsigned int length(std::vector<unsigned int> const &dim) const;
-  void support(double *lower, double *upper, unsigned int length,
+                           std::vector<unsigned long> const &lengths) const override;
+  bool checkParameterLength(std::vector<unsigned long> const &lengths) const override;
+  unsigned long length(std::vector<unsigned long> const &dim) const override;
+  void support(double *lower, double *upper, 
 	       std::vector<double const *> const &parameters,
-	       std::vector<unsigned int> const &lengths) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<unsigned long> const &lengths) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
   };
 
 }

--- a/src/distributions/DWN2.cc
+++ b/src/distributions/DWN2.cc
@@ -24,14 +24,14 @@ namespace RoBMA {
 DWN2::DWN2() : VectorDist("dwnorm_2s", 4) {}
 
 
-bool DWN2::checkParameterLength(std::vector<unsigned int> const &len) const
+bool DWN2::checkParameterLength(std::vector<unsigned long> const &len) const
 {
   // there is one less cut-point then weights
   return n_crit_x(len) == n_omega(len) - 1;
 }
 
 bool DWN2::checkParameterValue(std::vector<double const *> const &par,
-			    std::vector<unsigned int> const &len) const
+			    std::vector<unsigned long> const &len) const
 {
   bool crit_x_OK = true;
   bool omega_OK  = true;
@@ -52,10 +52,9 @@ bool DWN2::checkParameterValue(std::vector<double const *> const &par,
   return crit_x_OK && omega_OK && var_OK;
 }
 
-double DWN2::logDensity(double const *x, unsigned int length, PDFType type,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
+double DWN2::logDensity(double const *x, PDFType type,
+			std::vector<double const *> const &par,
+			std::vector<unsigned long> const &len) const
 {
   // reassign the addresses to pointers
   const double *mu     = par[0];
@@ -73,41 +72,30 @@ double DWN2::logDensity(double const *x, unsigned int length, PDFType type,
   return log_lik;
 }
 
-void DWN2::randomSample(double *x, unsigned int length,
+void DWN2::randomSample(double *x,
 			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper,
+			  std::vector<unsigned long> const &len,
 			  RNG *rng) const
 {
   // not implemented
 }
 
-void DWN2::support(double *lower, double *upper, unsigned int length,
+void DWN2::support(double *lower, double *upper,
 	     std::vector<double const *> const &par,
-	     std::vector<unsigned int> const &len) const
+	     std::vector<unsigned long> const &len) const
 {
   // no idea whether this is correct
-  for (unsigned int i = 0; i < length; ++i) {
+  for (unsigned long i = 0; i < length(len); ++i) {
 	  lower[i] = JAGS_NEGINF;
 	  upper[i] = JAGS_POSINF;
   }
 }
 
-unsigned int DWN2::length(std::vector<unsigned int> const &len) const
+unsigned long DWN2::length(std::vector<unsigned long> const &len) const
 {
   // no idea how this works
   return 1;
 }
-
-
-void DWN2::typicalValue(double *x, unsigned int length,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
-{
-  // not implemented
-}
-
 
 bool DWN2::isSupportFixed(std::vector<bool> const &fixmask) const
 {

--- a/src/distributions/DWN2.h
+++ b/src/distributions/DWN2.h
@@ -10,26 +10,20 @@ class DWN2 : public VectorDist
   public:
     DWN2();
     
-  double logDensity(double const *x, unsigned int length, PDFType tpye, 
+  double logDensity(double const *x,  PDFType type, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<unsigned long> const &lengths) const override;
+  void randomSample(double *x, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &par,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
+		    std::vector<unsigned long> const &lengths, RNG *rng) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-                           std::vector<unsigned int> const &lengths) const;
-  bool checkParameterLength(std::vector<unsigned int> const &lengths) const;
-  unsigned int length(std::vector<unsigned int> const &dim) const;
-  void support(double *lower, double *upper, unsigned int length,
+                           std::vector<unsigned long> const &lengths) const override;
+  bool checkParameterLength(std::vector<unsigned long> const &lengths) const override;
+  unsigned long length(std::vector<unsigned long> const &dim) const override;
+  void support(double *lower, double *upper, 
 	       std::vector<double const *> const &parameters,
-	       std::vector<unsigned int> const &lengths) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<unsigned long> const &lengths) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
   };
 
 }

--- a/src/distributions/DWNMIX.cc
+++ b/src/distributions/DWNMIX.cc
@@ -19,23 +19,22 @@ namespace RoBMA {
 
 DWNMIX::DWNMIX() : VectorDist("dwnorm_mix", 6) {}
 
-bool DWNMIX::checkParameterLength(std::vector<unsigned int> const &len) const
+bool DWNMIX::checkParameterLength(std::vector<unsigned long> const &len) const
 {
   // there is one less cut-point then weights
   return true;
 }
 
 bool DWNMIX::checkParameterValue(std::vector<double const *> const &par,
-			    std::vector<unsigned int> const &len) const
+			    std::vector<unsigned long> const &len) const
 {
   return true;
 }
 
 // Log Density
-double DWNMIX::logDensity(double const *x, unsigned int length, PDFType type,
+double DWNMIX::logDensity(double const *x, PDFType type,
 			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
+			  std::vector<unsigned long> const &len) const
 {
     // extract parameters
     const double *mu     = par[0];
@@ -69,41 +68,30 @@ double DWNMIX::logDensity(double const *x, unsigned int length, PDFType type,
     return log_lik;
 }
 
-void DWNMIX::randomSample(double *x, unsigned int length,
+void DWNMIX::randomSample(double *x,
 			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper,
+			  std::vector<unsigned long> const &len,
 			  RNG *rng) const
 {
   // not implemented
 }
 
-void DWNMIX::support(double *lower, double *upper, unsigned int length,
+void DWNMIX::support(double *lower, double *upper,
 	     std::vector<double const *> const &par,
-	     std::vector<unsigned int> const &len) const
+	     std::vector<unsigned long> const &len) const
 {
   // no idea whether this is correct
-  for (unsigned int i = 0; i < length; ++i) {
+  for (unsigned long i = 0; i < length(len); ++i) {
 	  lower[i] = JAGS_NEGINF;
 	  upper[i] = JAGS_POSINF;
   }
 }
 
-unsigned int DWNMIX::length(std::vector<unsigned int> const &len) const
+unsigned long DWNMIX::length(std::vector<unsigned long> const &len) const
 {
   // no idea how this works
   return 1;
 }
-
-
-void DWNMIX::typicalValue(double *x, unsigned int length,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
-{
-  // not implemented
-}
-
 
 bool DWNMIX::isSupportFixed(std::vector<bool> const &fixmask) const
 {

--- a/src/distributions/DWNMIX.h
+++ b/src/distributions/DWNMIX.h
@@ -10,26 +10,20 @@ class DWNMIX : public VectorDist
   public:
     DWNMIX();
     
-  double logDensity(double const *x, unsigned int length, PDFType tpye, 
+  double logDensity(double const *x, PDFType tpye, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<unsigned long> const &lengths) const override;
+  void randomSample(double *x,
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &par,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
+		    std::vector<unsigned long> const &lengths, RNG *rng) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-                           std::vector<unsigned int> const &lengths) const;
-  bool checkParameterLength(std::vector<unsigned int> const &lengths) const;
-  unsigned int length(std::vector<unsigned int> const &dim) const;
-  void support(double *lower, double *upper, unsigned int length,
+                           std::vector<unsigned long> const &lengths) const override;
+  bool checkParameterLength(std::vector<unsigned long> const &lengths) const override;
+  unsigned long length(std::vector<unsigned long> const &dim) const override;
+  void support(double *lower, double *upper,
 	       std::vector<double const *> const &parameters,
-	       std::vector<unsigned int> const &lengths) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<unsigned long> const &lengths) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
   };
 
 }

--- a/src/distributions/DWT1.cc
+++ b/src/distributions/DWT1.cc
@@ -21,14 +21,14 @@ namespace RoBMA {
 DWT1::DWT1() : VectorDist("dwt_1s", 4) {}
 
 
-bool DWT1::checkParameterLength(std::vector<unsigned int> const &len) const
+bool DWT1::checkParameterLength(std::vector<unsigned long> const &len) const
 {
   // there is one less cut-point then weights
   return n_crit_t(len) == n_omega(len) - 1;
 }
 
 bool DWT1::checkParameterValue(std::vector<double const *> const &par,
-			    std::vector<unsigned int> const &len) const
+			    std::vector<unsigned long> const &len) const
 {
   bool omega_OK  = true;
 
@@ -43,10 +43,9 @@ bool DWT1::checkParameterValue(std::vector<double const *> const &par,
   return omega_OK && df_OK;
 }
 
-double DWT1::logDensity(double const *x, unsigned int length, PDFType type,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
+double DWT1::logDensity(double const *x, PDFType type,
+			std::vector<double const *> const &par,
+			std::vector<unsigned long> const &len) const
 {
   double df    = *par[0];
   double ncp   = *par[1];
@@ -106,41 +105,30 @@ double DWT1::logDensity(double const *x, unsigned int length, PDFType type,
   return log_lik;
 }
 
-void DWT1::randomSample(double *x, unsigned int length,
+void DWT1::randomSample(double *x, 
 			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper,
+			  std::vector<unsigned long> const &len,
 			  RNG *rng) const
 {
   // not implemented
 }
 
-void DWT1::support(double *lower, double *upper, unsigned int length,
+void DWT1::support(double *lower, double *upper,
 	     std::vector<double const *> const &par,
-	     std::vector<unsigned int> const &len) const
+	     std::vector<unsigned long> const &len) const
 {
   // no idea whether this is correct
-  for (unsigned int i = 0; i < length; ++i) {
+  for (unsigned long i = 0; i < length(len); ++i) {
 	  lower[i] = JAGS_NEGINF;
 	  upper[i] = JAGS_POSINF;
   }
 }
 
-unsigned int DWT1::length(std::vector<unsigned int> const &len) const
+unsigned long DWT1::length(std::vector<unsigned long> const &len) const
 {
   // no idea how this works
   return 1;
 }
-
-
-void DWT1::typicalValue(double *x, unsigned int length,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
-{
-  // not implemented
-}
-
 
 bool DWT1::isSupportFixed(std::vector<bool> const &fixmask) const
 {

--- a/src/distributions/DWT1.h
+++ b/src/distributions/DWT1.h
@@ -10,26 +10,20 @@ class DWT1 : public VectorDist
   public:
     DWT1();
     
-  double logDensity(double const *x, unsigned int length, PDFType tpye, 
+  double logDensity(double const *x, PDFType tpye, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<unsigned long> const &lengths) const override;
+  void randomSample(double *x,
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &par,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
+		    std::vector<unsigned long> const &lengths, RNG *rng) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-                           std::vector<unsigned int> const &lengths) const;
-  bool checkParameterLength(std::vector<unsigned int> const &lengths) const;
-  unsigned int length(std::vector<unsigned int> const &dim) const;
-  void support(double *lower, double *upper, unsigned int length,
+                           std::vector<unsigned long> const &lengths) const override;
+  bool checkParameterLength(std::vector<unsigned long> const &lengths) const override;
+  unsigned long length(std::vector<unsigned long> const &dim) const override;
+  void support(double *lower, double *upper,
 	       std::vector<double const *> const &parameters,
-	       std::vector<unsigned int> const &lengths) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<unsigned long> const &lengths) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
   };
 
 }

--- a/src/distributions/DWT2.cc
+++ b/src/distributions/DWT2.cc
@@ -21,14 +21,14 @@ namespace RoBMA {
 DWT2::DWT2() : VectorDist("dwt_2s", 4) {}
 
 
-bool DWT2::checkParameterLength(std::vector<unsigned int> const &len) const
+bool DWT2::checkParameterLength(std::vector<unsigned long> const &len) const
 {
   // there is one less cut-point then weights
   return n_crit_t(len) == n_omega(len) - 1;
 }
 
 bool DWT2::checkParameterValue(std::vector<double const *> const &par,
-			    std::vector<unsigned int> const &len) const
+			    std::vector<unsigned long> const &len) const
 {
   bool crit_t_OK = true;
   bool omega_OK  = true;
@@ -49,10 +49,9 @@ bool DWT2::checkParameterValue(std::vector<double const *> const &par,
   return crit_t_OK && omega_OK && df_OK;
 }
 
-double DWT2::logDensity(double const *x, unsigned int length, PDFType type,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
+double DWT2::logDensity(double const *x, PDFType type,
+			std::vector<double const *> const &par,
+			std::vector<unsigned long> const &len) const
 {
   double abs_x = std::fabs(*x);
   double df    = *par[0];
@@ -113,41 +112,30 @@ double DWT2::logDensity(double const *x, unsigned int length, PDFType type,
   return log_lik;
 }
 
-void DWT2::randomSample(double *x, unsigned int length,
+void DWT2::randomSample(double *x, 
 			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper,
+			  std::vector<unsigned long> const &len,
 			  RNG *rng) const
 {
   // not implemented
 }
 
-void DWT2::support(double *lower, double *upper, unsigned int length,
+void DWT2::support(double *lower, double *upper, 
 	     std::vector<double const *> const &par,
-	     std::vector<unsigned int> const &len) const
+	     std::vector<unsigned long> const &len) const
 {
   // no idea whether this is correct
-  for (unsigned int i = 0; i < length; ++i) {
+  for (unsigned long i = 0; i < length(len); ++i) {
 	  lower[i] = JAGS_NEGINF;
 	  upper[i] = JAGS_POSINF;
   }
 }
 
-unsigned int DWT2::length(std::vector<unsigned int> const &len) const
+unsigned long DWT2::length(std::vector<unsigned long> const &len) const
 {
   // no idea how this works
   return 1;
 }
-
-
-void DWT2::typicalValue(double *x, unsigned int length,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
-{
-  // not implemented
-}
-
 
 bool DWT2::isSupportFixed(std::vector<bool> const &fixmask) const
 {

--- a/src/distributions/DWT2.h
+++ b/src/distributions/DWT2.h
@@ -10,26 +10,20 @@ class DWT2 : public VectorDist
   public:
     DWT2();
     
-  double logDensity(double const *x, unsigned int length, PDFType tpye, 
+  double logDensity(double const *x, PDFType tpye, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<unsigned long> const &lengths) const override;
+  void randomSample(double *x,
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &par,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
+		    std::vector<unsigned long> const &lengths, RNG *rng) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-                           std::vector<unsigned int> const &lengths) const;
-  bool checkParameterLength(std::vector<unsigned int> const &lengths) const;
-  unsigned int length(std::vector<unsigned int> const &dim) const;
-  void support(double *lower, double *upper, unsigned int length,
+                           std::vector<unsigned long> const &lengths) const override;
+  bool checkParameterLength(std::vector<unsigned long> const &lengths) const override;
+  unsigned long length(std::vector<unsigned long> const &dim) const override;
+  void support(double *lower, double *upper,
 	       std::vector<double const *> const &parameters,
-	       std::vector<unsigned int> const &lengths) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<unsigned long> const &lengths) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
   };
 
 }

--- a/src/distributions/DWWN1.cc
+++ b/src/distributions/DWWN1.cc
@@ -26,14 +26,14 @@ namespace RoBMA {
 DWWN1::DWWN1() : VectorDist("dwwnorm_1s", 5) {}
 
 
-bool DWWN1::checkParameterLength(std::vector<unsigned int> const &len) const
+bool DWWN1::checkParameterLength(std::vector<unsigned long> const &len) const
 {
   // there is one less cut-point then weights
   return n_crit_x(len) == n_omega(len) - 1;
 }
 
 bool DWWN1::checkParameterValue(std::vector<double const *> const &par,
-			    std::vector<unsigned int> const &len) const
+			    std::vector<unsigned long> const &len) const
 {
   bool omega_OK  = true;
 
@@ -49,10 +49,9 @@ bool DWWN1::checkParameterValue(std::vector<double const *> const &par,
   return omega_OK && var_OK && weight_OK;
 }
 
-double DWWN1::logDensity(double const *x, unsigned int length, PDFType type,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
+double DWWN1::logDensity(double const *x, PDFType type,
+			 std::vector<double const *> const &par,
+			 std::vector<unsigned long> const &len) const
 {
   // reassign the addresses to pointers
   const double *mu     = par[0];
@@ -71,41 +70,30 @@ double DWWN1::logDensity(double const *x, unsigned int length, PDFType type,
   return log_lik;
 }
 
-void DWWN1::randomSample(double *x, unsigned int length,
+void DWWN1::randomSample(double *x,
 			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper,
+			  std::vector<unsigned long> const &len,
 			  RNG *rng) const
 {
   // not implemented
 }
 
-void DWWN1::support(double *lower, double *upper, unsigned int length,
+void DWWN1::support(double *lower, double *upper,
 	     std::vector<double const *> const &par,
-	     std::vector<unsigned int> const &len) const
+	     std::vector<unsigned long> const &len) const
 {
   // no idea whether this is correct
-  for (unsigned int i = 0; i < length; ++i) {
+  for (unsigned long i = 0; i < length(len); ++i) {
 	  lower[i] = JAGS_NEGINF;
 	  upper[i] = JAGS_POSINF;
   }
 }
 
-unsigned int DWWN1::length(std::vector<unsigned int> const &len) const
+unsigned long DWWN1::length(std::vector<unsigned long> const &len) const
 {
   // no idea how this works
   return 1;
 }
-
-
-void DWWN1::typicalValue(double *x, unsigned int length,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
-{
-  // not implemented
-}
-
 
 bool DWWN1::isSupportFixed(std::vector<bool> const &fixmask) const
 {

--- a/src/distributions/DWWN1.h
+++ b/src/distributions/DWWN1.h
@@ -10,26 +10,20 @@ class DWWN1 : public VectorDist
   public:
     DWWN1();
     
-  double logDensity(double const *x, unsigned int length, PDFType tpye, 
+  double logDensity(double const *x, PDFType tpye, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<unsigned long> const &lengths) const override;
+  void randomSample(double *x,
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &par,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
+		    std::vector<unsigned long> const &lengths, RNG *rng) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-                           std::vector<unsigned int> const &lengths) const;
-  bool checkParameterLength(std::vector<unsigned int> const &lengths) const;
-  unsigned int length(std::vector<unsigned int> const &dim) const;
-  void support(double *lower, double *upper, unsigned int length,
+                           std::vector<unsigned long> const &lengths) const override;
+  bool checkParameterLength(std::vector<unsigned long> const &lengths) const override;
+  unsigned long length(std::vector<unsigned long> const &dim) const override;
+  void support(double *lower, double *upper,
 	       std::vector<double const *> const &parameters,
-	       std::vector<unsigned int> const &lengths) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<unsigned long> const &lengths) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
   };
 
 }

--- a/src/distributions/DWWN2.cc
+++ b/src/distributions/DWWN2.cc
@@ -25,14 +25,14 @@ namespace RoBMA {
 DWWN2::DWWN2() : VectorDist("dwwnorm_2s", 5) {}
 
 
-bool DWWN2::checkParameterLength(std::vector<unsigned int> const &len) const
+bool DWWN2::checkParameterLength(std::vector<unsigned long> const &len) const
 {
   // there is one less cut-point then weights
   return n_crit_x(len) == n_omega(len) - 1;
 }
 
 bool DWWN2::checkParameterValue(std::vector<double const *> const &par,
-			    std::vector<unsigned int> const &len) const
+			    std::vector<unsigned long> const &len) const
 {
   bool crit_x_OK = true;
   bool omega_OK  = true;
@@ -54,10 +54,9 @@ bool DWWN2::checkParameterValue(std::vector<double const *> const &par,
   return crit_x_OK && omega_OK && var_OK && weight_OK;
 }
 
-double DWWN2::logDensity(double const *x, unsigned int length, PDFType type,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
+double DWWN2::logDensity(double const *x, PDFType type,
+			 std::vector<double const *> const &par,
+			 std::vector<unsigned long> const &len) const
 {
   // reassign the addresses to pointers
   const double *mu     = par[0];
@@ -76,41 +75,30 @@ double DWWN2::logDensity(double const *x, unsigned int length, PDFType type,
   return log_lik;
 }
 
-void DWWN2::randomSample(double *x, unsigned int length,
+void DWWN2::randomSample(double *x, 
 			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper,
+			  std::vector<unsigned long> const &len,
 			  RNG *rng) const
 {
   // not implemented
 }
 
-void DWWN2::support(double *lower, double *upper, unsigned int length,
+void DWWN2::support(double *lower, double *upper, 
 	     std::vector<double const *> const &par,
-	     std::vector<unsigned int> const &len) const
+	     std::vector<unsigned long> const &len) const
 {
   // no idea whether this is correct
-  for (unsigned int i = 0; i < length; ++i) {
+  for (unsigned long i = 0; i < length(len); ++i) {
 	  lower[i] = JAGS_NEGINF;
 	  upper[i] = JAGS_POSINF;
   }
 }
 
-unsigned int DWWN2::length(std::vector<unsigned int> const &len) const
+unsigned long DWWN2::length(std::vector<unsigned long> const &len) const
 {
   // no idea how this works
   return 1;
 }
-
-
-void DWWN2::typicalValue(double *x, unsigned int length,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
-{
-  // not implemented
-}
-
 
 bool DWWN2::isSupportFixed(std::vector<bool> const &fixmask) const
 {

--- a/src/distributions/DWWN2.h
+++ b/src/distributions/DWWN2.h
@@ -10,26 +10,20 @@ class DWWN2 : public VectorDist
   public:
     DWWN2();
     
-  double logDensity(double const *x, unsigned int length, PDFType tpye, 
+  double logDensity(double const *x, PDFType tpye, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<unsigned long> const &lengths) const override;
+  void randomSample(double *x,
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &par,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
+		    std::vector<unsigned long> const &lengths, RNG *rng) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-                           std::vector<unsigned int> const &lengths) const;
-  bool checkParameterLength(std::vector<unsigned int> const &lengths) const;
-  unsigned int length(std::vector<unsigned int> const &dim) const;
-  void support(double *lower, double *upper, unsigned int length,
+                           std::vector<unsigned long> const &lengths) const override;
+  bool checkParameterLength(std::vector<unsigned long> const &lengths) const override;
+  unsigned long length(std::vector<unsigned long> const &dim) const override;
+  void support(double *lower, double *upper,
 	       std::vector<double const *> const &parameters,
-	       std::vector<unsigned int> const &lengths) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<unsigned long> const &lengths) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
   };
 
 }

--- a/src/distributions/DWWNMIX.cc
+++ b/src/distributions/DWWNMIX.cc
@@ -19,23 +19,23 @@ namespace RoBMA {
 
 DWWNMIX::DWWNMIX() : VectorDist("dwwnorm_mix", 7) {}
 
-bool DWWNMIX::checkParameterLength(std::vector<unsigned int> const &len) const
+bool DWWNMIX::checkParameterLength(std::vector<unsigned long> const &len) const
 {
   // there is one less cut-point then weights
   return true;
 }
 
 bool DWWNMIX::checkParameterValue(std::vector<double const *> const &par,
-			    std::vector<unsigned int> const &len) const
+			    std::vector<unsigned long> const &len) const
 {
   return true;
 }
 
 // Log Density
-double DWWNMIX::logDensity(double const *x, unsigned int length, PDFType type,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
+double DWWNMIX::logDensity(double const *x, PDFType type,
+			   std::vector<double const *> const &par,
+			   std::vector<unsigned long> const &len) const
+
 {
     // extract parameters
     const double *mu     = par[0];
@@ -71,41 +71,30 @@ double DWWNMIX::logDensity(double const *x, unsigned int length, PDFType type,
     return log_lik;
 }
 
-void DWWNMIX::randomSample(double *x, unsigned int length,
+void DWWNMIX::randomSample(double *x,
 			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper,
+			  std::vector<unsigned long> const &len,
 			  RNG *rng) const
 {
   // not implemented
 }
 
-void DWWNMIX::support(double *lower, double *upper, unsigned int length,
+void DWWNMIX::support(double *lower, double *upper,
 	     std::vector<double const *> const &par,
-	     std::vector<unsigned int> const &len) const
+	     std::vector<unsigned long> const &len) const
 {
   // no idea whether this is correct
-  for (unsigned int i = 0; i < length; ++i) {
+  for (unsigned long i = 0; i < length(len); ++i) {
 	  lower[i] = JAGS_NEGINF;
 	  upper[i] = JAGS_POSINF;
   }
 }
 
-unsigned int DWWNMIX::length(std::vector<unsigned int> const &len) const
+unsigned long DWWNMIX::length(std::vector<unsigned long> const &len) const
 {
   // no idea how this works
   return 1;
 }
-
-
-void DWWNMIX::typicalValue(double *x, unsigned int length,
-			  std::vector<double const *> const &par,
-			  std::vector<unsigned int> const &len,
-			  double const *lower, double const *upper) const
-{
-  // not implemented
-}
-
 
 bool DWWNMIX::isSupportFixed(std::vector<bool> const &fixmask) const
 {

--- a/src/distributions/DWWNMIX.h
+++ b/src/distributions/DWWNMIX.h
@@ -10,26 +10,20 @@ class DWWNMIX : public VectorDist
   public:
     DWWNMIX();
     
-  double logDensity(double const *x, unsigned int length, PDFType tpye, 
+  double logDensity(double const *x, PDFType tpye, 
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
-  void randomSample(double *x, unsigned int length,
+		    std::vector<unsigned long> const &lengths) const override;
+  void randomSample(double *x,
 		    std::vector<double const *> const &parameters,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper, RNG *rng) const;
-  void typicalValue(double *x, unsigned int length,
-		    std::vector<double const *> const &par,
-		    std::vector<unsigned int> const &lengths,
-		    double const *lower, double const *upper) const;
+		    std::vector<unsigned long> const &lengths, RNG *rng) const override;
   bool checkParameterValue(std::vector<double const *> const &parameters,
-                           std::vector<unsigned int> const &lengths) const;
-  bool checkParameterLength(std::vector<unsigned int> const &lengths) const;
-  unsigned int length(std::vector<unsigned int> const &dim) const;
-  void support(double *lower, double *upper, unsigned int length,
+                           std::vector<unsigned long> const &lengths) const override;
+  bool checkParameterLength(std::vector<unsigned long> const &lengths) const override;
+  unsigned long length(std::vector<unsigned long> const &dim) const override;
+  void support(double *lower, double *upper,
 	       std::vector<double const *> const &parameters,
-	       std::vector<unsigned int> const &lengths) const;
-  bool isSupportFixed(std::vector<bool> const &fixmask) const;
+	       std::vector<unsigned long> const &lengths) const override;
+  bool isSupportFixed(std::vector<bool> const &fixmask) const override;
   };
 
 }

--- a/src/functions/mnorm.cc
+++ b/src/functions/mnorm.cc
@@ -12,7 +12,7 @@ namespace jags {
     // one-sided multivariate normal
     mnorm_lpdf::mnorm_lpdf() :ArrayFunction("mnorm_lpdf", 3)
     {}
-    void mnorm_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const
+    void mnorm_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *x      = args[0];
@@ -26,26 +26,26 @@ namespace jags {
       *value = cpp_mnorm_lpdf(&x[0], &mu[0], &sigma[0], K);;
     }
 
-    bool mnorm_lpdf::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool mnorm_lpdf::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-		bool mnorm_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+		bool mnorm_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-    std::vector<unsigned int> mnorm_lpdf::dim(std::vector<std::vector<unsigned int> > const &dims,	std::vector<double const *> const &values) const
+    std::vector<unsigned long> mnorm_lpdf::dim(std::vector<std::vector<unsigned long> > const &dims,	std::vector<double const *> const &values) const
     {
-	    return std::vector<unsigned int>(1,1);
+	    return std::vector<unsigned long>(1,1);
     }
 
 
     //// vector input type ----
     mnorm_v_lpdf::mnorm_v_lpdf() :ArrayFunction("mnorm_v_lpdf", 6)
     {}
-    void mnorm_v_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const
+    void mnorm_v_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *x      = args[0];
@@ -110,19 +110,19 @@ namespace jags {
       *value = log_lik;
     }
 
-    bool mnorm_v_lpdf::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool mnorm_v_lpdf::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-		bool mnorm_v_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+		bool mnorm_v_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-    std::vector<unsigned int> mnorm_v_lpdf::dim(std::vector<std::vector<unsigned int> > const &dims,	std::vector<double const *> const &values) const
+    std::vector<unsigned long> mnorm_v_lpdf::dim(std::vector<std::vector<unsigned long> > const &dims,	std::vector<double const *> const &values) const
     {
-	    return std::vector<unsigned int>(1,1);
+	    return std::vector<unsigned long>(1,1);
     }
 
   }

--- a/src/functions/mnorm.h
+++ b/src/functions/mnorm.h
@@ -11,10 +11,10 @@ namespace jags {
       public:
         mnorm_lpdf();
 
-		void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const;
-		bool checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const;
-		bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const;
-		std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims, std::vector<double const *> const &values) const;
+		void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const override;
+		bool checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const override;
+		bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const override;
+		std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims, std::vector<double const *> const &values) const override;
     };
 
     class mnorm_v_lpdf : public ArrayFunction
@@ -22,10 +22,10 @@ namespace jags {
       public:
         mnorm_v_lpdf();
 
-		void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const;
-		bool checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const;
-		bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const;
-		std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims, std::vector<double const *> const &values) const;
+		void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const override;
+		bool checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const override;
+		bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const override;
+		std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims, std::vector<double const *> const &values) const override;
     };
   }
 }

--- a/src/functions/wmnorm.cc
+++ b/src/functions/wmnorm.cc
@@ -13,7 +13,7 @@ namespace jags {
     // one-sided normal
     wnorm_1s_lpdf::wnorm_1s_lpdf() :ArrayFunction("wnorm_1s_lpdf", 5)
     {}
-    void wnorm_1s_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const
+    void wnorm_1s_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *x      = args[0];
@@ -28,25 +28,25 @@ namespace jags {
       *value = cpp_wnorm_1s_lpdf(&x[0], &mu[0], &sigma[0], &crit_x[0], &omega[0], J);
     }
 
-    bool wnorm_1s_lpdf::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool wnorm_1s_lpdf::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-    bool wnorm_1s_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+    bool wnorm_1s_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-    std::vector<unsigned int> wnorm_1s_lpdf::dim(std::vector<std::vector<unsigned int> > const &dims,	std::vector<double const *> const &values) const
+    std::vector<unsigned long> wnorm_1s_lpdf::dim(std::vector<std::vector<unsigned long> > const &dims,	std::vector<double const *> const &values) const
     {
-      return std::vector<unsigned int>(1,1);
+      return std::vector<unsigned long>(1,1);
     }
 
     // two-sided normal
     wnorm_2s_lpdf::wnorm_2s_lpdf() :ArrayFunction("wnorm_2s_lpdf", 5)
     {}
-    void wnorm_2s_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const
+    void wnorm_2s_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *x      = args[0];
@@ -61,26 +61,26 @@ namespace jags {
       *value = cpp_wnorm_2s_lpdf(&x[0], &mu[0], &sigma[0], &crit_x[0], &omega[0], J);
     }
 
-    bool wnorm_2s_lpdf::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool wnorm_2s_lpdf::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-    bool wnorm_2s_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+    bool wnorm_2s_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-    std::vector<unsigned int> wnorm_2s_lpdf::dim(std::vector<std::vector<unsigned int> > const &dims,	std::vector<double const *> const &values) const
+    std::vector<unsigned long> wnorm_2s_lpdf::dim(std::vector<std::vector<unsigned long> > const &dims,	std::vector<double const *> const &values) const
     {
-      return std::vector<unsigned int>(1,1);
+      return std::vector<unsigned long>(1,1);
     }
 
 
     // one-sided multivariate normal
     wmnorm_1s_lpdf::wmnorm_1s_lpdf() :ArrayFunction("wmnorm_1s_lpdf", 5)
     {}
-    void wmnorm_1s_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const
+    void wmnorm_1s_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *x      = args[0];
@@ -97,26 +97,26 @@ namespace jags {
       *value = cpp_wmnorm_1s_lpdf(&x[0], &mu[0], &sigma[0], &crit_x[0], &omega[0], K, J);
     }
 
-    bool wmnorm_1s_lpdf::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool wmnorm_1s_lpdf::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-		bool wmnorm_1s_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+		bool wmnorm_1s_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-    std::vector<unsigned int> wmnorm_1s_lpdf::dim(std::vector<std::vector<unsigned int> > const &dims,	std::vector<double const *> const &values) const
+    std::vector<unsigned long> wmnorm_1s_lpdf::dim(std::vector<std::vector<unsigned long> > const &dims,	std::vector<double const *> const &values) const
     {
-	    return std::vector<unsigned int>(1,1);
+	    return std::vector<unsigned long>(1,1);
     }
 
 
     // two-sided multivariate normal
     wmnorm_2s_lpdf::wmnorm_2s_lpdf() :ArrayFunction("wmnorm_2s_lpdf", 5)
     {}
-    void wmnorm_2s_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const
+    void wmnorm_2s_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *x      = args[0];
@@ -133,19 +133,19 @@ namespace jags {
       *value = cpp_wmnorm_2s_lpdf(&x[0], &mu[0], &sigma[0], &crit_x[0], &omega[0], K, J);
     }
 
-    bool wmnorm_2s_lpdf::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool wmnorm_2s_lpdf::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-		bool wmnorm_2s_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+		bool wmnorm_2s_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-    std::vector<unsigned int> wmnorm_2s_lpdf::dim(std::vector<std::vector<unsigned int> > const &dims,	std::vector<double const *> const &values) const
+    std::vector<unsigned long> wmnorm_2s_lpdf::dim(std::vector<std::vector<unsigned long> > const &dims,	std::vector<double const *> const &values) const
     {
-	    return std::vector<unsigned int>(1,1);
+	    return std::vector<unsigned long>(1,1);
     }
 
 
@@ -153,7 +153,7 @@ namespace jags {
     // one-sided multivariate normal
     wmnorm_1s_v_lpdf::wmnorm_1s_v_lpdf() :ArrayFunction("wmnorm_1s_v_lpdf", 8)
     {}
-    void wmnorm_1s_v_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const
+    void wmnorm_1s_v_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *x      = args[0];
@@ -229,26 +229,26 @@ namespace jags {
       *value = log_lik;
     }
 
-    bool wmnorm_1s_v_lpdf::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool wmnorm_1s_v_lpdf::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-		bool wmnorm_1s_v_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+		bool wmnorm_1s_v_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-    std::vector<unsigned int> wmnorm_1s_v_lpdf::dim(std::vector<std::vector<unsigned int> > const &dims,	std::vector<double const *> const &values) const
+    std::vector<unsigned long> wmnorm_1s_v_lpdf::dim(std::vector<std::vector<unsigned long> > const &dims,	std::vector<double const *> const &values) const
     {
-	    return std::vector<unsigned int>(1,1);
+	    return std::vector<unsigned long>(1,1);
     }
 
 
     // two-sided multivariate normal
     wmnorm_2s_v_lpdf::wmnorm_2s_v_lpdf() :ArrayFunction("wmnorm_2s_v_lpdf", 8)
     {}
-    void wmnorm_2s_v_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const
+    void wmnorm_2s_v_lpdf::evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const
     {
       // reassign the addresses to pointers
       const double *x      = args[0];
@@ -324,19 +324,19 @@ namespace jags {
       *value = log_lik;
     }
 
-    bool wmnorm_2s_v_lpdf::checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const
+    bool wmnorm_2s_v_lpdf::checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-		bool wmnorm_2s_v_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const
+		bool wmnorm_2s_v_lpdf::checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const
     {
       return true;
     }
 
-    std::vector<unsigned int> wmnorm_2s_v_lpdf::dim(std::vector<std::vector<unsigned int> > const &dims,	std::vector<double const *> const &values) const
+    std::vector<unsigned long> wmnorm_2s_v_lpdf::dim(std::vector<std::vector<unsigned long> > const &dims,	std::vector<double const *> const &values) const
     {
-	    return std::vector<unsigned int>(1,1);
+	    return std::vector<unsigned long>(1,1);
     }
   }
 }

--- a/src/functions/wmnorm.h
+++ b/src/functions/wmnorm.h
@@ -11,10 +11,10 @@ namespace jags {
     public:
       wnorm_1s_lpdf();
 
-      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const;
-      std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims, std::vector<double const *> const &values) const;
+      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const override;
+      std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims, std::vector<double const *> const &values) const override;
     };
 
     class wnorm_2s_lpdf : public ArrayFunction
@@ -22,10 +22,10 @@ namespace jags {
     public:
       wnorm_2s_lpdf();
 
-      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const;
-      std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims, std::vector<double const *> const &values) const;
+      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const override;
+      std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims, std::vector<double const *> const &values) const override;
     };
 
     class wmnorm_1s_lpdf : public ArrayFunction
@@ -33,10 +33,10 @@ namespace jags {
       public:
         wmnorm_1s_lpdf();
 
-      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const;
-      std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims, std::vector<double const *> const &values) const;
+      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const override;
+      std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims, std::vector<double const *> const &values) const override;
     };
 
     class wmnorm_2s_lpdf : public ArrayFunction
@@ -44,10 +44,10 @@ namespace jags {
       public:
         wmnorm_2s_lpdf();
 
-      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const;
-      std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims, std::vector<double const *> const &values) const;
+      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const override;
+      std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims, std::vector<double const *> const &values) const override;
     };
 
     class wmnorm_1s_v_lpdf : public ArrayFunction
@@ -55,10 +55,10 @@ namespace jags {
       public:
         wmnorm_1s_v_lpdf();
 
-      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const;
-      std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims, std::vector<double const *> const &values) const;
+      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const override;
+      std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims, std::vector<double const *> const &values) const override;
     };
 
     class wmnorm_2s_v_lpdf : public ArrayFunction
@@ -66,10 +66,10 @@ namespace jags {
       public:
         wmnorm_2s_v_lpdf();
 
-      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterDim (std::vector<std::vector<unsigned int> > const &dims) const;
-      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned int> > const &dims) const;
-      std::vector<unsigned int> dim(std::vector<std::vector<unsigned int> > const &dims, std::vector<double const *> const &values) const;
+      void evaluate(double *value, std::vector<double const *> const &args, std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterDim (std::vector<std::vector<unsigned long> > const &dims) const override;
+      bool checkParameterValue(std::vector<double const *> const &par, std::vector<std::vector<unsigned long> > const &dims) const override;
+      std::vector<unsigned long> dim(std::vector<std::vector<unsigned long> > const &dims, std::vector<double const *> const &values) const override;
     };
   }
 }

--- a/src/jagsversions.h
+++ b/src/jagsversions.h
@@ -3,7 +3,7 @@
     The previous version of the file is Copyright (C) Matthew Denwood, licensed under GPL-2.
 	
 	This header file sorts the necessary macros for compiling against 
-	JAGS 4
+	JAGS 5
  */
 
 #ifndef JAGS_VERSIONS_H_
@@ -33,11 +33,11 @@
 #endif // JAGS_MAJOR_ASSUMED
 
 // Check version of JAGS is OK:
-#if JAGS_MAJOR_USED > 4
+#if JAGS_MAJOR_USED > 5
 #warning "Compiling against a later version of JAGS than has been tested for this version of RoBMA ... you should probably update the RoBMA package!"
 #endif
 
-#if JAGS_MAJOR_USED < 4
+#if JAGS_MAJOR_USED < 5
 #error "This version of the RoBMA package requires compilation against JAGS version 4 or later"
 #endif
 

--- a/src/source/#tools.cc#
+++ b/src/source/#tools.cc#
@@ -1,0 +1,395 @@
+0#include "tools.h"
+#include <JRmath.h>
+#include <cmath>
+#include <algorithm>
+#include <numeric> 
+#include <vector>
+#include "mnorm.h"
+
+// assigns log of weights product corresponding to the outcome x based on a one/two-sided weightfunction
+double log_weight_onesided(double const *x, double const *crit_x, double const *omega, const int J)
+{
+	double w = -68;
+
+	if(*x >= *(crit_x + J - 2)){
+	// return the last omega if x > last crit_x
+		w = *(omega + J - 1);
+	}else if(*x < *crit_x){
+	// return the first omega if x < first crit_x
+		w = *omega;
+	}else{
+	// check the remaining cutpoints sequentially
+		for(int i = 1; i < J; i++){
+			if( (*x >= *(crit_x + i - 1)) && (*x < *(crit_x + i)) ){
+				w = *(omega + i);
+				break;
+			}
+		}
+	}
+
+	return std::log(w);
+}
+
+double log_weight_twosided(double const *x, double const *crit_x, double const *omega, const int J)
+{
+	double w = -68;
+	double abs_x = std::fabs(*x);
+
+	if(abs_x >= *(crit_x + J - 2)){
+	// return the last omega if abs(x) > last crit_x
+		w = *(omega + J - 1);
+	}else if(abs_x < *crit_x){
+	// return the first omega if abs(x) < first crit_x
+		w = *omega;
+	}else{
+	// check the remaining cutpoints sequentially
+		for(int i = 1; i < J; i++){
+			if( (abs_x >= *(crit_x + i - 1)) && (abs_x < *(crit_x + i)) ){
+				w = *(omega + i);
+				break;
+			}
+		}
+	}
+	return std::log(w);
+}
+
+// compute the standardizing constant for a one/two-sided weightfunctions
+double log_std_constant_onesided(double const *x, double const *const_mu, double const *sigma, double const *crit_x, double const *omega, const int J) {
+
+    // Pre-allocate the denoms vector with size J
+    std::vector<double> denoms(J, 0.0);
+
+    // Compute the first denominator
+    denoms[0] = pnorm(crit_x[0], *const_mu, *sigma, true, false);
+    denoms[0] = (denoms[0] < 0.0) ? 0.0 : denoms[0];
+    double denom_sum = denoms[0];
+
+    // Compute the middle denominators
+    for (int j = 1; j < J - 1; ++j) {
+        denoms[j] = pnorm(crit_x[j], *const_mu, *sigma, true, false) - denom_sum;
+        denoms[j] = (denoms[j] < 0.0) ? 0.0 : denoms[j];
+        denom_sum += denoms[j];
+    }
+
+    // Compute the last denominator
+    if (J > 1) { // Ensure there is more than one element
+        denoms[J - 1] = 1.0 - denom_sum;
+        denoms[J - 1] = (denoms[J - 1] < 0.0) ? 0.0 : denoms[J - 1];
+    }
+
+    // Pre-allocate log_terms vector with maximum possible size J
+    std::vector<double> log_terms;
+    log_terms.reserve(J);
+
+    // Populate log_terms with log(denoms[k]) + log(omega[k]) where denoms[k] and omega[k] > 0
+    for (int k = 0; k < J; ++k) {
+        if (denoms[k] > 0.0 && omega[k] > 0.0) {
+            log_terms.push_back(std::log(denoms[k]) + std::log(omega[k]));
+        }
+    }
+
+    // If no valid terms, return negative infinity
+    if (log_terms.empty()) {
+        return -INFINITY;
+    }
+
+    // Find the maximum log_term to use in the log-sum-exp trick
+    double max_log = *std::max_element(log_terms.begin(), log_terms.end());
+
+    // Compute the sum of exponentials of (log_terms - max_log)
+    double sum_exp = 0.0;
+    for (const auto& log_val : log_terms) {
+        sum_exp += std::exp(log_val - max_log);
+    }
+
+    // Compute log_sum_exp
+    double log_sum_exp = max_log + std::log(sum_exp);
+
+    return log_sum_exp;
+}
+
+double log_std_constant_twosided(double const *x, double const *const_mu, double const *sigma, double const *crit_x, double const *omega, const int J) {
+
+    // Pre-allocate the denoms vector with size J
+    std::vector<double> denoms(J, 0.0);
+
+    // Compute the first denominator: P(X < crit_x[0]) - P(X < -crit_x[0])
+    denoms[0] = pnorm(crit_x[0], *const_mu, *sigma, true, false) - pnorm(-crit_x[0], *const_mu, *sigma, true, false);
+    denoms[0] = (denoms[0] < 0.0) ? 0.0 : denoms[0];
+    double denom_sum = denoms[0];
+
+    // Compute the middle denominators: P(X < crit_x[j]) - P(X < -crit_x[j]) - denom_sum
+    for (int j = 1; j < J - 1; ++j) {
+        denoms[j] = pnorm(crit_x[j], *const_mu, *sigma, true, false) - pnorm(-crit_x[j], *const_mu, *sigma, true, false) - denom_sum;
+        denoms[j] = (denoms[j] < 0.0) ? 0.0 : denoms[j];
+        denom_sum += denoms[j];
+    }
+
+    // Compute the last denominator: 1.0 - denom_sum
+    if (J > 1) { // Ensure there is more than one element
+        denoms[J - 1] = 1.0 - denom_sum;
+        denoms[J - 1] = (denoms[J - 1] < 0.0) ? 0.0 : denoms[J - 1];
+    }
+
+    // Pre-allocate log_terms vector with maximum possible size J
+    std::vector<double> log_terms;
+    log_terms.reserve(J);
+
+    // Populate log_terms with log(denoms[k]) + log(omega[k]) where denoms[k] and omega[k] > 0
+    for (int k = 0; k < J; ++k) {
+        if (denoms[k] > 0.0 && omega[k] > 0.0) {
+            log_terms.push_back(std::log(denoms[k]) + std::log(omega[k]));
+        }
+    }
+
+    // If no valid terms, return negative infinity
+    if (log_terms.empty()) {
+        return -INFINITY;
+    }
+
+    // Find the maximum log_term to use in the log-sum-exp trick
+    double max_log = *std::max_element(log_terms.begin(), log_terms.end());
+
+    // Compute the sum of exponentials of (log_terms[k] - max_log)
+    double sum_exp = 0.0;
+    for (const auto& log_val : log_terms) {
+        sum_exp += std::exp(log_val - max_log);
+    }
+
+    // Compute log_sum_exp
+    double log_sum_exp = max_log + std::log(sum_exp);
+
+    return log_sum_exp;
+}
+
+double log_std_m_constant_onesided(double const *x, double const *const_mu, double const *sigma, double const *crit_x, double const *omega ,const int K, const int J)
+{
+  double std_constant = 0;
+
+  // create dynamically allocated arrays for covariance matrix decomposition (and non-constat mu)
+  double * sigma_stdev;
+  double * sigma_corr;
+  double * mu;
+
+  sigma_stdev = new double [K];
+  sigma_corr  = new double [K * (K - 1) / 2];
+  mu          = new double [K];
+
+  for(int k = 0; k < K; k++){
+    *(sigma_stdev + k) = std::sqrt( *(sigma+ K * k + k) );
+    *(mu + k)          = *(const_mu + k);
+  }
+  for(int k = 0; k < K; k++){
+    for(int j = 0; j < K && j < k; j++){
+      *(sigma_corr + k * (k - 1) / 2 + j) = *(sigma + K * k + j) / std::sqrt( *(sigma + K * k + k) * *(sigma + K * j + j));
+    }
+  }
+
+  // create dynamically allocated arrays for the current lower bounds, upper bounds and  infinity indicator
+  double * temp_lower;
+  double * temp_upper;
+  int    * temp_infin;
+
+  temp_lower = new double [K];
+  temp_upper = new double [K];
+  temp_infin = new int    [K];
+
+  // current weight holder
+  double temp_log_weight;
+
+  // indexes tracker for weights assignment
+  int * index_weights;
+  index_weights = new int [K];
+  for(int k = 0; k < K; k++){
+    *(index_weights + k) = 0;
+  }
+
+  // iterate over all subspaces created by the cutpoints
+  for(int i = 0; i < std::pow(J, K); i++){
+
+  	// reset the current weight
+  	temp_log_weight = 0;
+
+    // assign proper upper and lower cutopoints & weight
+    for(int k = 0; k < K; k++){
+
+      // weight
+      temp_log_weight += std::log(*(omega + *(index_weights + k)));
+
+      // the upper and lower bounds
+      if(*(index_weights + k) == 0){
+        // the lower bound is - infinity for the first cutpoint
+        *(temp_lower + k) = 0;
+        *(temp_upper + k) = *(crit_x + k * (J - 1) + *(index_weights + k));
+        *(temp_infin + k) = 0; // 0 for lower bound =  -inf
+      }else if(*(index_weights + k) == J - 1){
+        // the upper bound is + infinity for the last cutpoint
+        *(temp_lower + k) = *(crit_x + k * (J - 1) + *(index_weights + k) - 1);
+        *(temp_upper + k) = 0;
+        *(temp_infin + k) = 1; // 1 for upper bound = +inf
+      }else{
+        *(temp_lower + k) = *(crit_x + k * (J - 1) + *(index_weights + k) - 1);
+        *(temp_upper + k) = *(crit_x + k * (J - 1) + *(index_weights + k));
+        *(temp_infin + k) = 2; // 2 for neither of the bound is infinite
+      }
+    }
+
+  	// get the current weighted probability
+  	double temp_prob = cpp_mnorm_cdf(&temp_lower[0], &temp_upper[0], &temp_infin[0], &mu[0], &sigma_stdev[0], &sigma_corr[0], K);
+  	// check and skip negative numbers due to numerical impressions for very low probabilities
+  	if(temp_prob > 0){
+  	  std_constant += std::exp(std::log(temp_prob) + temp_log_weight);
+  	}
+
+	  // increase index for the next iteration
+	  if((i + 1) < std::pow(J, K)){
+	    increase_index( &index_weights[0], K-1, J-1);
+	  }
+  }
+
+  // clean the memory
+  delete[] sigma_stdev;
+  delete[] sigma_corr;
+  delete[] mu;
+  delete[] temp_lower;
+  delete[] temp_upper;
+  delete[] temp_infin;
+  delete[] index_weights;
+
+  return std::log(std_constant);
+}
+
+double log_std_m_constant_twosided(double const *x, double const *const_mu, double const *sigma, double const *crit_x, double const *omega ,const int K, const int J)
+{
+  double log_std_constant = 0;
+
+  // turn the two-sided selection into one-sided selection
+  double * omega_onesided;
+  double * crit_x_onesided;
+
+  omega_onesided  = new double [2 * J - 1];
+  crit_x_onesided = new double [2 * (J - 1) * K];
+
+  for(int i = 0; i < 2 * J - 1; i++){
+    if(i < J){
+        *(omega_onesided + i) = *(omega + (J - 1) - i);
+    }else{
+      *(omega_onesided + i) = *(omega + i - (J - 1));
+    }
+  }
+
+  for(int k = 0; k < K; k++){
+    for(int j = 0; j < 2 * (J - 1); j++){
+      if(j < (J - 1)){
+          *(crit_x_onesided + k * 2 * (J - 1) + j) = - *(crit_x + k * (J - 1) + (J - 2) - j);
+        }else{
+          *(crit_x_onesided + k * 2 * (J - 1) + j) =   *(crit_x + k * (J - 1) + j - (J - 1));
+        }
+      }
+  }
+
+  log_std_constant = log_std_m_constant_onesided(&x[0], &const_mu[0], &sigma[0], &crit_x_onesided[0], &omega_onesided[0], K, 2 * J - 1);
+
+  // clean the memory
+  delete[] omega_onesided;
+  delete[] crit_x_onesided;
+
+  return log_std_constant;
+}
+
+//// additional helper functions
+// increases index carrying the cutoff coordinates by one
+void increase_index(int *index, int i, int max_i)
+{
+  if( *(index + i) == (max_i)){
+    *(index + i) = 0;
+    increase_index(&index[0], i-1, max_i);
+  }else{
+    *(index + i) += 1;
+  }
+}
+
+// parsing vector input into different pieces
+double * extract_x_v(const double *x_v, int indx_start, int K)
+{
+  double * this_x;
+  this_x = new double [K];
+
+  // cout << "x = ";
+  for(int k = 0; k < K; k++){
+    *(this_x + k) = *(x_v  + indx_start + k);
+    // cout << *(this_x + k) << "\t";
+  }
+
+  return &this_x[0];
+}
+
+double * extract_mu_v(const double *mu_v,  int indx_start, int K)
+{
+  double * this_mu;
+  this_mu = new double [K];
+
+  // cout << "mu = ";
+  for(int k = 0; k < K; k++){
+    *(this_mu + k) = *(mu_v + indx_start + k);
+    // cout << *(this_mu + k) << "\t";
+  }
+
+  return &this_mu[0];
+}
+
+double * extract_sigma_v(const double *se2_v, const double *tau2, double cov, int indx_start, int K)
+{
+  double * this_sigma;
+  this_sigma  = new double [K * K];
+
+  for(int k = 0; k < K; k++){
+    // cout << "sigma[" << k << ",] = ";
+    for(int j = 0; j < K; j++){
+      if(k == j){
+        *(this_sigma + k * K + j) = *(se2_v + indx_start + k) + *tau2;
+      }else{
+        *(this_sigma + k * K + j) = cov;
+      }
+      // cout << *(this_sigma + k * K + j) << "\t";
+    }
+  }
+
+  return &this_sigma[0];
+}
+
+double * extract_crit_x_v(const double *crit_x_v, int indx_start, int K, const int J)
+{
+  double * this_crit_x;
+  this_crit_x  = new double [K * (J-1)];
+
+  for(int k = 0; k < K; k++){
+    // cout << "crit_x[" << k << ",] = ";
+    for(int j = 0; j < J - 1 ; j++){
+      *(this_crit_x + k * (J - 1) + j) = *(crit_x_v + (indx_start + k) * (J - 1) + j);
+      // cout << *(this_crit_x + k * (J-1) + j) << "\t";
+    }
+  }
+
+  return &this_crit_x[0];
+}
+
+double ddirichlet(const std::vector<double>& x, const std::vector<double>& alpha){
+
+  int k = x.size();
+
+  double prod_gamma = 0.0, sum_alpha = 0.0, p_tmp = 0.0, beta_const = 0.0;
+
+  for (int j = 0; j < k; j++) {
+    double alpha_val = alpha[j];
+    double x_val = x[j];
+    sum_alpha += alpha_val;
+    prod_gamma += std::lgamma(alpha_val);
+    p_tmp += std::log(x_val) * (alpha_val - 1.0);
+  }
+
+  beta_const = prod_gamma - std::lgamma(sum_alpha);
+  double p = p_tmp - beta_const;
+
+  return p;
+}

--- a/src/transformations/omega.cc
+++ b/src/transformations/omega.cc
@@ -14,7 +14,7 @@ namespace jags {
 
     void eta2omega::evaluate(double *value,
                          std::vector<double const *> const &args,
-                         std::vector<unsigned int> const &lengths) const
+                         std::vector<unsigned long> const &lengths) const
     {
         // extract parameters
         const double *eta_vector  = args[0];
@@ -67,14 +67,14 @@ namespace jags {
         }
     }
 
-    unsigned int eta2omega::length(std::vector<unsigned int> const &lengths,
+    unsigned long eta2omega::length(std::vector<unsigned long> const &lengths,
                                   std::vector<double const *> const &args) const
     {
         // Output length matches the length of the second std::vector
         return lengths[1];
     }
 
-    bool eta2omega::checkParameterLength(std::vector<unsigned int> const &len) const
+    bool eta2omega::checkParameterLength(std::vector<unsigned long> const &len) const
     {
         return true;
     }
@@ -95,7 +95,7 @@ namespace jags {
     }
 
     bool eta2omega::checkParameterValue(std::vector<double const *> const &args,
-                                       std::vector<unsigned int> const &lens) const
+                                       std::vector<unsigned long> const &lens) const
     {
         return true;
     }

--- a/src/transformations/omega.h
+++ b/src/transformations/omega.h
@@ -12,15 +12,15 @@ namespace jags {
         eta2omega();
         void evaluate(double *value, 
                       std::vector<double const *> const &values,
-                      std::vector<unsigned int> const &lengths) const;
-        unsigned int length(std::vector<unsigned int> const &lengths,
+                      std::vector<unsigned long> const &lengths) const;
+        unsigned long length(std::vector<unsigned long> const &lengths,
                             std::vector<double const *> const &values) const;
-        bool checkParameterLength(std::vector<unsigned int> const &args) const;
+        bool checkParameterLength(std::vector<unsigned long> const &args) const;
         bool isDiscreteValued(std::vector<bool> const &mask) const;
         bool checkParameterDiscrete(std::vector<bool> const &mask) const;
         bool checkParameterFixed(std::vector<bool> const &mask) const;
         bool checkParameterValue(std::vector<double const *> const &args,
-                                 std::vector<unsigned int> const &lens) const;
+                                 std::vector<unsigned long> const &lens) const;
     };
 
     }


### PR DESCRIPTION
With the forthcoming release of JAGS 5.0.0 I am testing CRAN packages to see if they work with the new version. Since RoBMA uses the C++ API it needs to be patched to work with JAGS 5.0.0

The main changes to the JAGS API are:
* Use unsigned long instead of unsigned int for object sizes
*  Redundant method typicalValue is removed from distributions (It was not implemented in RoBMA)
* Redundant argument length is removed from VectorDist and ArrayDist (It was never dereferenced in any method in RoBMA). Similarly for VectorFunction and ArrayFunction.

Changes make the patched version dependent on JAGS 5.0.0 and above.

You have a quick CRAN test that captures the output from some short MCMC runs. This test is fragile as we cannot guarantee reproducibility at this level between versions. If you want to keep the test then you will need to recapture new output using JAGS 5.0.0. However, I recommend that you wait until the release as other changes may take place as I work through other CRAN packages.